### PR TITLE
Refactor: Use virtual environments for dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ news-blink-project/
 │   │   ├── static/           # Archivos estáticos del backend (ej. index.html)
 │   │   ├── utils/            # Utilidades varias
 │   │   └── app.py            # Aplicación principal Flask
-│   │   └── requirements.txt  # Dependencias de Python
 │   └── .git/                 # Repositorio Git
 ├── news-blink-frontend/
 │   ├── public/               # Archivos estáticos públicos
@@ -66,51 +65,77 @@ Es un **prerrequisito indispensable** tener Ollama instalado y ejecutándose en 
     ```
     Este proceso puede tardar un tiempo. Asegúrate de que el modelo `llama3` esté disponible, ya que el código del backend está configurado para usarlo por defecto.
 
-### 2.2. Instalación Unificada (Backend y Frontend)
+### 2.2. Configuración del Backend (Python)
 
-El proceso de instalación se ha simplificado para configurar tanto el backend como el frontend.
+El backend de News Blink requiere Python y sus dependencias gestionadas a través de un entorno virtual.
 
-1.  **Navega al directorio raíz del proyecto:**
-    (Por ejemplo: `/home/ubuntu/news-blink-app/news-blink-project`)
+1.  **Crea un entorno virtual:**
+    Navega al directorio raíz del proyecto y ejecuta:
     ```bash
-    cd ruta/al/directorio/raiz/del/proyecto
+    python -m venv venv
     ```
+    Esto creará una carpeta `venv` en el raíz del proyecto.
 
-2.  **Ejecuta el script de instalación:**
-    Utiliza `pip` para instalar el proyecto. Este comando se encargará de:
-    *   Instalar las dependencias de Python para el backend (Flask, nltk, etc.).
-    *   Intentar instalar `pnpm` globalmente usando `npm install -g pnpm` (si `npm` está disponible y los permisos lo permiten). `pnpm` es necesario para las dependencias del frontend.
-    *   Navegar al directorio `news-blink-frontend` y ejecutar `pnpm install` para instalar las dependencias del frontend (como React, Vite, etc.).
+2.  **Activa el entorno virtual:**
+    *   En macOS/Linux:
+        ```bash
+        source venv/bin/activate
+        ```
+    *   En Windows (Git Bash o similar):
+        ```bash
+        source venv/Scripts/activate
+        ```
+    *   En Windows (Command Prompt):
+        ```bash
+        .\venv\Scripts\activate
+        ```
+    Deberías ver `(venv)` al principio de tu prompt de terminal.
 
+3.  **Instala las dependencias de Python:**
+    Asegúrate de que tu entorno virtual esté activado. Luego, desde el directorio raíz del proyecto, ejecuta:
     ```bash
-    pip install .
+    pip install -r requirements.txt
     ```
+    Alternativamente, si deseas que el comando `news-blink-backend` esté disponible directamente (por ejemplo, para desarrollo o si `start.py` lo utiliza preferentemente), puedes instalar el paquete en modo editable:
+    ```bash
+    pip install -e .
+    ```
+    Esto también instalará las dependencias listadas en `setup.py` (que son las mismas de `requirements.txt`).
 
-3.  **Nota sobre la instalación de dependencias del Frontend:**
-    El proceso de `pip install .` intentará automatizar la instalación de las dependencias del frontend. Sin embargo, debido a posibles limitaciones del entorno de ejecución (como errores de permisos con `sudo` o problemas con `npm`/`pnpm` en entornos específicos), este paso podría fallar.
+### 2.3. Configuración del Frontend (Node.js/pnpm)
 
-    Si después de ejecutar `pip install .`, la aplicación frontend no se inicia correctamente (por ejemplo, con errores como "vite: not found" o relacionados con `node_modules`), es posible que necesites realizar los siguientes pasos manualmente:
+El frontend de News Blink está construido con React y Vite, y sus dependencias se gestionan con pnpm.
 
-    *   **Asegúrate de tener `pnpm` instalado globalmente:**
-        Si el script no pudo instalarlo o si prefieres hacerlo manualmente:
+1.  **Prerrequisitos (Node.js y pnpm):**
+    *   Asegúrate de tener Node.js instalado. Se recomienda usar un gestor de versiones como [nvm](https://github.com/nvm-sh/nvm) para instalar y gestionar Node.js.
+    *   Instala pnpm. Si tienes Node.js v16.13 o posterior, puedes habilitar `corepack` (que viene con Node.js) y luego instalar pnpm:
+        ```bash
+        corepack enable
+        corepack prepare pnpm@latest --activate
+        ```
+        Alternativamente, puedes instalar pnpm globalmente usando npm (que viene con Node.js):
         ```bash
         npm install -g pnpm
         ```
-    *   **Instala las dependencias del frontend manualmente:**
-        Navega al directorio del frontend:
+        Verifica la instalación con `pnpm --version`.
+
+2.  **Instala las dependencias del frontend:**
+    *   Navega al directorio del frontend:
         ```bash
         cd news-blink-frontend
         ```
-        Y luego ejecuta:
+    *   Instala las dependencias:
         ```bash
         pnpm install
         ```
-        Luego, regresa al directorio raíz del proyecto para ejecutar la aplicación.
+    *   Regresa al directorio raíz del proyecto:
         ```bash
         cd ..
         ```
 
 ## 3. Ejecución de la Aplicación
+
+**Importante:** Antes de ejecutar la aplicación, asegúrate de que tu entorno virtual de Python (creado en el paso 2.2) esté activado.
 
 Una vez completada la configuración e instalación:
 

--- a/news-blink-backend/src/requirements.txt
+++ b/news-blink-backend/src/requirements.txt
@@ -1,7 +1,0 @@
-Flask==2.3.3
-Flask-CORS==4.0.0
-requests==2.31.0
-beautifulsoup4==4.12.2
-nltk==3.8.1
-ollama==0.1.7
-

--- a/setup.py
+++ b/setup.py
@@ -1,69 +1,4 @@
-import os
-import subprocess
 from setuptools import setup, find_packages
-from setuptools.command.install import install
-
-class CustomInstallCommand(install):
-    """Customized setuptools install command."""
-    def run(self):
-        # Attempt to install pnpm globally
-        try:
-            print("Attempting to install pnpm globally...")
-            # Using shell=True can be a security risk if command components are from untrusted input.
-            # Here, 'npm install -g pnpm' is static, reducing risk.
-            # On some systems, npm might be a script that requires shell, or pnpm might be installed via shell.
-            npm_command = "npm install -g pnpm"
-            pnpm_install_proc = subprocess.run(npm_command, shell=True, check=False, capture_output=True, text=True)
-            if pnpm_install_proc.returncode == 0:
-                print("pnpm global install command executed successfully (or pnpm already installed).")
-            else:
-                print(f"pnpm global install command failed. STDOUT: {pnpm_install_proc.stdout} STDERR: {pnpm_install_proc.stderr}")
-
-            # Verify pnpm installation
-            pnpm_check = subprocess.run(['pnpm', '--version'], capture_output=True, text=True, shell=True)
-            if pnpm_check.returncode == 0:
-                print(f"pnpm successfully installed or already present: version {pnpm_check.stdout.strip()}")
-            else:
-                print("pnpm not found after installation attempt. Please install pnpm manually (e.g., 'npm install -g pnpm') and ensure it's in your PATH.")
-        except FileNotFoundError:
-            print("npm command not found. Please ensure Node.js and npm are installed and in your PATH.")
-        except Exception as e:
-            print(f"An error occurred during pnpm installation: {e}")
-
-        # Store the original directory
-        original_dir = os.getcwd()
-        frontend_dir = os.path.join(original_dir, 'news-blink-frontend')
-
-        if os.path.isdir(frontend_dir):
-            try:
-                print(f"Changing directory to {frontend_dir}")
-                os.chdir(frontend_dir)
-
-                print("Running 'pnpm install' in news-blink-frontend...")
-                # Using shell=True for pnpm as well, as pnpm might be a .cmd or shell script,
-                # especially after being installed by npm.
-                pnpm_install_result = subprocess.run('pnpm install', shell=True, check=True, capture_output=True, text=True)
-                print(f"pnpm install completed successfully in news-blink-frontend. STDOUT: {pnpm_install_result.stdout}")
-
-            except subprocess.CalledProcessError as e:
-                print(f"Error during 'pnpm install' in {frontend_dir}. Return code: {e.returncode}")
-                print(f"STDOUT: {e.stdout}")
-                print(f"STDERR: {e.stderr}")
-                print("Please ensure pnpm is installed correctly and the frontend dependencies are valid.")
-            except FileNotFoundError:
-                print(f"pnpm command not found in {frontend_dir} or PATH. Make sure pnpm is installed (e.g. npm install -g pnpm).")
-            except Exception as e:
-                print(f"An unexpected error occurred in frontend setup: {e}")
-            finally:
-                print(f"Changing back to original directory: {original_dir}")
-                os.chdir(original_dir)
-        else:
-            print(f"Frontend directory {frontend_dir} not found. Skipping pnpm install.")
-
-        # Run the original install command
-        print("Proceeding with standard Python package installation...")
-        super().run()
-        print("Standard Python package installation finished.")
 
 setup(
     name='news-blink-backend',
@@ -87,7 +22,4 @@ setup(
         ],
     },
     python_requires='>=3.9',
-    cmdclass={
-        'install': CustomInstallCommand,
-    },
 )


### PR DESCRIPTION
This commit modifies the project setup to use virtual environments for both backend and frontend dependencies, preventing project bloat and global conflicts.

Changes include:
- Consolidated duplicate `requirements.txt`.
- Removed custom pnpm global installation and frontend dependency installation from `setup.py`.
- Updated `README.md` with detailed instructions for setting up Python virtual environments and separate pnpm-based frontend dependency installation.
- `start.py` remains largely unchanged but now expects a pre-configured environment.