### PR TITLE
Here's the commit message I've drafted:

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+install_blink_news.sh text eol=lf


### PR DESCRIPTION
Add .gitattributes to enforce LF line endings for installer script

This commit introduces a `.gitattributes` file to ensure that `install_blink_news.sh` uses Unix-style (LF) line endings across all developer environments, regardless of their global Git `core.autocrlf` setting.

The `.gitattributes` file contains:
install_blink_news.sh text eol=lf

This is intended to resolve issues where the script would fail on Windows systems (using bash interpreters like Git Bash) due to CRLF line endings being automatically introduced by Git if `core.autocrlf` was set to `true`. Enforcing LF endings for this script file should prevent the `: command not found` errors.