### PR TITLE
Fix: Ensure setuptools is available for setup.py install

### DIFF
--- a/install_blink_news.sh
+++ b/install_blink_news.sh
@@ -33,6 +33,13 @@ then
 fi
 echo "--- Virtual environment 'blink_venv' created successfully. ---"
 
+echo "--- Upgrading pip, setuptools, and wheel in virtual environment... ---"
+if ! blink_venv/bin/python -m pip install --upgrade pip setuptools wheel; then
+    echo "--- ERROR: Failed to upgrade pip, setuptools, or wheel. ---"
+    exit 1
+fi
+echo "--- Build tools upgraded successfully. ---"
+
 # Install dependencies using pip from the virtual environment
 echo "--- Installing dependencies from requirements.txt into blink_venv... ---"
 if ! blink_venv/bin/pip install -r requirements.txt; then


### PR DESCRIPTION
Modifies `install_blink_news.sh` to explicitly install/upgrade pip, setuptools, and wheel within the virtual environment immediately after its creation.

This is to prevent `ModuleNotFoundError: No module named 'setuptools'` when the script later tries to run `blink_venv/bin/python setup.py install`. Ensuring these core build tools are present and up-to-date in the virtual environment should make the installation process more robust, especially for environments where the default venv might be very minimal.