### PR TITLE
Fix(installer): Use --copies for venv creation

### DIFF
--- a/install_blink_news.sh
+++ b/install_blink_news.sh
@@ -26,7 +26,7 @@ echo "--- pip3 found. ---"
 
 # Create a virtual environment
 echo "--- Creating virtual environment (blink_venv)... ---"
-if ! python3 -m venv blink_venv
+if ! python3 -m venv --copies blink_venv
 then
     echo "--- ERROR: Failed to create virtual environment. ---"
     exit 1


### PR DESCRIPTION
I've modified `install_blink_news.sh` to use the `--copies` flag when creating the Python virtual environment (`python3 -m venv --copies blink_venv`).

This change aims to create a more robust and self-contained virtual environment, particularly on Windows systems using Git Bash where symlinking behavior for Python interpreters within the venv can lead to issues (e.g., the venv's Python executables incorrectly pointing to a generic system Python like /usr/bin/python3 instead of the Python used to create the venv).

Using `--copies` should ensure that the Python interpreter inside the venv is a direct copy of the one used to create it, making activation and subsequent script execution within the venv more reliable.