### PR TITLE
Fix(installer): Robustly find venv Python (Scripts/python.exe or bin/…

### DIFF
--- a/install_blink_news.sh
+++ b/install_blink_news.sh
@@ -33,16 +33,30 @@ then
 fi
 echo "--- Virtual environment 'blink_venv' created successfully. ---"
 
+# Determine the path to python executable within the venv
+VENV_PYTHON_EXEC="blink_venv/bin/python" # Default for POSIX-like shims in Git Bash
+if [ -f "blink_venv/Scripts/python.exe" ]; then
+    VENV_PYTHON_EXEC="blink_venv/Scripts/python.exe"
+    echo "--- Found Windows-style venv Python at $VENV_PYTHON_EXEC ---"
+elif [ -f "blink_venv/bin/python" ]; then
+    echo "--- Found POSIX-style venv Python at $VENV_PYTHON_EXEC ---"
+else
+    echo "--- ERROR: Python executable not found in blink_venv/Scripts or blink_venv/bin. ---"
+    exit 1
+fi
+
 echo "--- Upgrading pip, setuptools, and wheel in virtual environment... ---"
-if ! blink_venv/bin/python -m pip install --upgrade pip setuptools wheel; then
+if ! "$VENV_PYTHON_EXEC" -m pip install --upgrade pip setuptools wheel; then
     echo "--- ERROR: Failed to upgrade pip, setuptools, or wheel. ---"
     exit 1
 fi
 echo "--- Build tools upgraded successfully. ---"
 
 # Install dependencies using pip from the virtual environment
+# Note: pip itself is usually directly available in blink_venv/bin/pip or blink_venv/Scripts/pip.
+# Using "$VENV_PYTHON_EXEC -m pip" is a robust way to call the venv's pip.
 echo "--- Installing dependencies from requirements.txt into blink_venv... ---"
-if ! blink_venv/bin/pip install -r requirements.txt; then
+if ! "$VENV_PYTHON_EXEC" -m pip install -r requirements.txt; then
     echo "--- ERROR: Failed to install dependencies from requirements.txt. ---"
     exit 1
 fi
@@ -50,7 +64,7 @@ echo "--- Dependencies installed successfully. ---"
 
 # Install BLINK NEWS application using python from the virtual environment
 echo "--- Installing BLINK NEWS application into blink_venv... ---"
-if ! blink_venv/bin/python setup.py install; then
+if ! "$VENV_PYTHON_EXEC" setup.py install; then
     echo "--- ERROR: Failed to install BLINK NEWS application. ---"
     exit 1
 fi


### PR DESCRIPTION
…python)

I modified `install_blink_news.sh` to intelligently locate the Python interpreter within the created virtual environment (`blink_venv`).

Changes:
- After venv creation, the script now checks for the existence of `blink_venv/Scripts/python.exe` (common on Windows) and then `blink_venv/bin/python` (common in POSIX environments like Git Bash).
- The found path is stored in a variable `VENV_PYTHON_EXEC`.
- If neither is found, the script exits with an error.
- All subsequent calls to Python or pip within the virtual environment (for upgrading build tools, installing requirements, and running `setup.py install`) now use this dynamically determined `$VENV_PYTHON_EXEC`.
- Pip commands are standardized to use `$VENV_PYTHON_EXEC -m pip ...` for better reliability.

This addresses issues where the script previously failed if `blink_venv/bin/python` was not the correct or existing path to the venv's interpreter, especially in mixed Windows/Git Bash environments potentially influenced by tools like pyenv. This change makes the installer more resilient.