### PR TITLE
Alright, I've updated the PowerShell installer to enable Vite's debug…

### DIFF
--- a/Install-And-Run-BlinkNews.ps1
+++ b/Install-And-Run-BlinkNews.ps1
@@ -409,7 +409,7 @@ try {
             Write-Error "Failed to run 'pnpm install' for frontend at '$($FrontendPathAbs)'. Error: $($_.Exception.Message)"
             Write-Warning "The frontend might not start correctly without its dependencies."
         }
-        Start-Process powershell -ArgumentList "-NoExit", "-Command", "& $PnpmCmdForAppStart --prefix '$FrontendPathAbs' run dev" -WindowStyle Normal
+        Start-Process powershell -ArgumentList "-NoExit", "-Command", "& $PnpmCmdForAppStart --prefix '$FrontendPathAbs' run dev -- --debug" -WindowStyle Normal
         Write-Host "Frontend process launch command issued."
         Write-Host "Look for a new window. Frontend typically runs on http://localhost:5173"
     } catch {


### PR DESCRIPTION
… mode.

I modified `Install-And-Run-BlinkNews.ps1` so that it passes the `--debug` flag to the `vite` command when starting the frontend development server.

This should give us more detailed logs from Vite, which will hopefully help figure out why the frontend is reported as running on localhost:5173 but isn't showing up in your browser.