### PR TITLE
Fix: Explicitly set publicDir and appType in Vite config

### DIFF
--- a/news-blink-frontend/vite.config.js
+++ b/news-blink-frontend/vite.config.js
@@ -17,5 +17,7 @@ export default defineConfig({
         changeOrigin: true,
       }
     }
-  }
+  },
+  publicDir: false, // Explicitly disable the public directory
+  appType: 'spa',   // Explicitly set app type to SPA
 })


### PR DESCRIPTION
To address a 404 error when serving index.html, this change modifies news-blink-frontend/vite.config.js to:

- Set `publicDir: false`: This explicitly tells Vite not to look for a `public` directory, ensuring it serves `index.html` from the project root.
- Set `appType: 'spa'`: This explicitly defines the application type, reinforcing the standard behavior for Single Page Applications.

These changes aim to resolve issues where Vite might not correctly locate or serve the main HTML file despite it being present in the root directory.