### PR TITLE
Fix: Explicitly set server host in Vite config

### DIFF
--- a/news-blink-frontend/vite.config.js
+++ b/news-blink-frontend/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: '127.0.0.1', // Explicitly set the host
     proxy: {
       '/api': {
         target: 'http://localhost:5000',


### PR DESCRIPTION
To further troubleshoot a 404 error when serving index.html, this change modifies news-blink-frontend/vite.config.js to include `host: '127.0.0.1'` within the `server` configuration.

This forces Vite to listen specifically on the IPv4 loopback address, which can sometimes help resolve issues related to localhost resolution or network interface binding on certain systems.