### PR TITLE
Fix: Restore frontend entrypoint and basic App component

### DIFF
--- a/news-blink-frontend/src/App.jsx
+++ b/news-blink-frontend/src/App.jsx
@@ -1,1 +1,12 @@
-{"code":"rate-limited","message":"You have hit the rate limit. Please <a class=\"__boltUpgradePlan__\">Upgrade</a> to keep chatting, or you can continue coding for free in the editor.","providerLimitHit":false,"isRetryable":true}
+import React from 'react';
+
+function App() {
+  return (
+    <div>
+      <h1>Hello from Blink News App!</h1>
+      {/* You will need to restore your application's specific components and structure here */}
+    </div>
+  );
+}
+
+export default App;

--- a/news-blink-frontend/src/main.jsx
+++ b/news-blink-frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)


### PR DESCRIPTION
- Creates news-blink-frontend/src/main.jsx with standard React/Vite setup to serve as your application entrypoint. This resolves the issue where Vite could not find /src/main.jsx.
- Replaces the content of news-blink-frontend/src/App.jsx with a basic functional React component. The previous content was found to be corrupted (contained a JSON error message).

This change should allow your frontend to load without the 'Failed to load /src/main.jsx' error. Further work will be needed to restore your application's specific UI and logic within App.jsx and its child components.