### PR TITLE
Update content generators and add management scripts

### DIFF
--- a/clear_cache.sh
+++ b/clear_cache.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "Borrando contenido generado..."
+BASE_DATA_DIR="news-blink-backend/src/data"
+DIRECTORIES_TO_CLEAN=("blinks" "articles" "superior_notes" "topic_searches" "raw_news")
+
+for dir in "${DIRECTORIES_TO_CLEAN[@]}"; do
+    TARGET_PATH="$BASE_DATA_DIR/$dir"
+    if [ -d "$TARGET_PATH" ]; then
+        echo "Limpiando $TARGET_PATH/..."
+        find "$TARGET_PATH" -type f -name "*.json" -delete
+    fi
+done
+echo "Limpieza completada."

--- a/models/superior_note_generator.py
+++ b/models/superior_note_generator.py
@@ -34,7 +34,7 @@ class SuperiorNoteGenerator:
 
         # Inicializar el cliente de Ollama
         self.ollama_client = ollama.Client(host='http://localhost:11434')
-        self.ollama_model = 'llama3'  # Modelo por defecto
+        self.ollama_model = 'qwen3:32b'  # Modelo por defecto
 
     def generate_superior_note(self, articles_group, topic):
         """

--- a/regenerate_content.sh
+++ b/regenerate_content.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Enviando solicitud para regenerar Blinks de la página principal..."
+curl "http://localhost:5000/api/news?refresh=true"
+echo -e "\n\nSolicitud de regeneración enviada. Monitorea los logs del backend."
+echo "Para generar una nota de un tema específico, modifica y usa este comando:"
+echo 'curl -X POST -H "Content-Type: application/json" -d '\''{"topic": "Tu Tema Aqui"}'\'' http://localhost:5000/api/topic_search'


### PR DESCRIPTION
This commit includes the following changes:

- Updated `models/blink_generator.py`:
    - Changed ollama_model to 'qwen3:32b'.
    - Updated the prompt for summarizing news articles to be more specific and in Spanish.
    - Modified the response processing to clean points using regex and handle cases where the number of points is less than requested by using a fallback mechanism.
- Updated `models/superior_note_generator.py`:
    - Changed ollama_model to 'qwen3:32b'.
- Created `clear_cache.sh`:
    - A new script to clear generated content (JSON files) from specified data directories.
    - Made the script executable.
- Created `regenerate_content.sh`:
    - A new script to trigger content regeneration via API calls.
    - Includes a command to refresh main page Blinks and an example command for topic-specific note generation.
    - Made the script executable.