### PR TITLE
Fix: Correct SyntaxError in agent_tools.py

### DIFF
--- a/models/agent_tools.py
+++ b/models/agent_tools.py
@@ -52,11 +52,8 @@ def buscar_en_la_web(query: str) -> str:
         if not results:
             return "No se encontraron resultados."
 
-        return "
-".join([
-            f"Título: {res['title']}
-URL: {res['href']}
----"
+        return "\n".join([
+            f"Título: {res['title']}\nURL: {res['href']}\n---"
             for res in results
         ])
 


### PR DESCRIPTION
This commit fixes an unterminated string literal in the `buscar_en_la_web` function in `models/agent_tools.py`.

The error was caused by a missing newline character after an opening double quote in a return statement. This has been corrected to ensure proper string formatting and joining of search results.