### PR TITLE
Fix: Remove trailing artifact from agent_tools.py

### DIFF
--- a/models/agent_tools.py
+++ b/models/agent_tools.py
@@ -96,4 +96,3 @@ def leer_contenido_web(url: str) -> str:
     finally:
         if driver:
             driver.quit()
-```


### PR DESCRIPTION
This commit corrects a SyntaxError in models/agent_tools.py by updating the file content to ensure no trailing characters or markdown artifacts (like '```') were present.

This was causing an 'invalid syntax' error during Python parsing.