### PR TITLE
feat: Dockerize frontend and add to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 
 services:
+  # Servicio del Backend (sin cambios)
   backend:
     build: .
     container_name: blink-news-backend
@@ -11,12 +12,22 @@ services:
       - ./models:/app/models
       - ./routes:/app/routes
       - ./start.py:/app/start.py
-      # No montar app.py si vamos a ejecutar el que está en el src directamente
       - ./news-blink-backend/src/app.py:/app/news-blink-backend/src/app.py
       - ./news-blink-backend/src/data:/app/news-blink-backend/src/data
     restart: unless-stopped
-    # --- LÍNEA AÑADIDA ---
-    # Esta línea sobreescribe el CMD del Dockerfile y ejecuta directamente
-    # la aplicación Flask, evitando el script start.py.
-    # El flag -u es para que los logs de Python aparezcan inmediatamente.
     command: python -u -m flask run --host=0.0.0.0 --port=5000
+
+  # --- NUEVO SERVICIO DEL FRONTEND ---
+  frontend:
+    build:
+      context: ./news-blink-frontend # El contexto es la carpeta del frontend
+      dockerfile: Dockerfile.frontend # El Dockerfile que acabamos de crear
+    container_name: blink-news-frontend
+    ports:
+      - "5173:5173" # Mapear el puerto de Vite
+    volumes:
+      # Montar el código fuente para que el Hot-Reloading funcione
+      - ./news-blink-frontend:/app
+      # Excluir node_modules para usar los del contenedor, que son más rápidos
+      - /app/node_modules
+    restart: unless-stopped

--- a/news-blink-frontend/Dockerfile.frontend
+++ b/news-blink-frontend/Dockerfile.frontend
@@ -1,0 +1,25 @@
+# news-blink-frontend/Dockerfile.frontend
+
+# Usar una imagen oficial de Node.js como base
+FROM node:20-alpine
+
+# Establecer el directorio de trabajo
+WORKDIR /app
+
+# Instalar pnpm
+RUN npm install -g pnpm
+
+# Copiar los archivos de manifiesto del proyecto
+COPY package.json pnpm-lock.yaml ./
+
+# Instalar las dependencias
+RUN pnpm install
+
+# Copiar el resto del código del frontend
+COPY . .
+
+# Exponer el puerto que usa Vite
+EXPOSE 5173
+
+# Comando para iniciar el servidor de desarrollo de Vite
+CMD ["pnpm", "run", "dev", "--host"]


### PR DESCRIPTION
This commit introduces Docker support for the frontend application and integrates it into the existing docker-compose setup.

Key changes:
- Added `news-blink-frontend/Dockerfile.frontend` to define the build process for the frontend image.
- Updated `docker-compose.yml` to include a new `frontend` service:
    - Builds the frontend image using the new Dockerfile.
    - Maps port 5173 for Vite dev server access.
    - Mounts the frontend source code for hot-reloading.
    - Excludes `node_modules` from the host mount to use container-native dependencies for better performance.

This allows both backend and frontend services to be managed by a single `docker-compose up` command, creating a unified and portable development environment.