### PR TITLE
feat: Add .dockerignore for frontend service

### DIFF
--- a/news-blink-frontend/.dockerignore
+++ b/news-blink-frontend/.dockerignore
@@ -1,0 +1,2 @@
+# Ignorar las dependencias locales para que Docker no intente copiarlas
+node_modules


### PR DESCRIPTION
This commit introduces a `.dockerignore` file in the `news-blink-frontend` directory.

The primary purpose of this file is to exclude `node_modules/` from the Docker build context when creating the frontend image. This prevents local frontend dependencies from being unnecessarily copied into the image, leading to:
- Faster image build times.
- Smaller image sizes.
- Avoidance of potential conflicts between host and container dependencies.

The `docker-compose.yml` already correctly handles `node_modules` isolation at runtime using an anonymous volume; this change complements that by optimizing the build process.