### PR TITLE
Here's the rewritten message:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       - ./news-blink-backend/src/app.py:/app/news-blink-backend/src/app.py
       - ./news-blink-backend/src/data:/app/news-blink-backend/src/data
     restart: unless-stopped
+    environment:
+      # Le decimos al contenedor que la URL de Ollama es la dirección especial del host
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
     command: python -u -m flask run --host=0.0.0.0 --port=5000
 
   # --- NUEVO SERVICIO DEL FRONTEND ---

--- a/models/blink_generator.py
+++ b/models/blink_generator.py
@@ -32,8 +32,9 @@ class BlinkGenerator:
         # Inicializar el generador de imágenes
         # self.image_generator = ImageGenerator() # <-- LÍNEA COMENTADA
 
-        # Inicializar el cliente de Ollama
-        self.ollama_client = ollama.Client(host='http://localhost:11434') # Asume Ollama corriendo localmente
+        # Leer la URL de Ollama desde la variable de entorno
+        ollama_base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+        self.ollama_client = ollama.Client(host=ollama_base_url)
         self.ollama_model = 'qwen3:32b' # Modelo por defecto, se puede configurar
 
     def generate_blink_from_news_group(self, news_group):

--- a/models/news_agent.py
+++ b/models/news_agent.py
@@ -1,16 +1,20 @@
 # models/news_agent.py
-
+import os # <-- Añadir import
 from langchain_ollama.llms import OllamaLLM
 from langchain import hub
 from langchain.agents import AgentExecutor, create_react_agent
 from models.agent_tools import buscar_en_la_web, leer_contenido_web
+
+# Leer la URL de Ollama desde la variable de entorno, con un valor por defecto
+ollama_base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
 
 def crear_agente_de_noticias():
     """
     Crea y configura el agente de IA con sus herramientas y lógica.
     """
     # 1. Inicializar el modelo de Ollama
-    llm = OllamaLLM(model="llama3")
+    # Usar la variable para configurar el cliente
+    llm = OllamaLLM(model="llama3", base_url=ollama_base_url)
 
     # 2. Definir la lista de herramientas
     tools = [buscar_en_la_web, leer_contenido_web]

--- a/models/superior_note_generator.py
+++ b/models/superior_note_generator.py
@@ -32,8 +32,9 @@ class SuperiorNoteGenerator:
         # Inicializar el generador de imágenes
         # self.image_generator = ImageGenerator() # <-- LÍNEA COMENTADA
 
-        # Inicializar el cliente de Ollama
-        self.ollama_client = ollama.Client(host='http://localhost:11434')
+        # Leer la URL de Ollama desde la variable de entorno
+        ollama_base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+        self.ollama_client = ollama.Client(host=ollama_base_url)
         self.ollama_model = 'qwen3:32b'  # Modelo por defecto
 
     def generate_superior_note(self, articles_group, topic):


### PR DESCRIPTION
Hi there! I've made a fix to ensure the backend service can connect to Ollama when running inside Docker.

Previously, when the backend was in a Docker container, it couldn't reach an Ollama instance on your machine because `localhost` inside the container points to the container itself, not to your computer.

Here's what I changed:

1.  **`docker-compose.yml`**:
    *   I've set an environment variable `OLLAMA_BASE_URL` for the `backend` service to `http://host.docker.internal:11434`. This special address allows services inside Docker to reach your computer.

2.  **Python Models (`news_agent.py`, `blink_generator.py`, `superior_note_generator.py`)**:
    *   I've updated these files to use the `os` module.
    *   They now get the Ollama base URL from the `OLLAMA_BASE_URL` environment variable.
    *   If that variable isn't set (for example, when you're developing locally outside of Docker), they'll default to `http://localhost:11434` to maintain compatibility.
    *   The connections to Ollama are now set up using this dynamically configured base URL.

This means the application can now connect to Ollama smoothly, whether it's running directly on your machine or inside a Docker container, without needing different code for each setup.