### PR TITLE
feat: Filter article publishing by categories in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,5 +67,6 @@
   "default_articles_per_source": 8,
   "max_articles_homepage": 0,
   "recency_filter_hours": 24,
-  "similarity_threshold": 0.6
+  "similarity_threshold": 0.6,
+  "allowed_publish_categories": ["tecnologia"]
 }


### PR DESCRIPTION
This commit introduces a mechanism to filter which news articles are published based on a list of allowed categories specified in `config.json`.

Modifications:

1.  **`config.json`:** Added a new key `allowed_publish_categories` (e.g., `["tecnologia"]`) to define which categories are permitted for publication.
2.  **`routes/api.py` (`collect_and_process_news`):**
    *   Loads the `allowed_publish_categories` list from the application's
      configuration.
    *   After I determine and verify an article's category, this
      final category is checked against the `allowed_publish_categories`.
    *   If the article's category is not in the allowed list, the article
      (blink and full content) is skipped and not saved. A log message
      indicates this action.

This change ensures that the application adheres to the configured categories for publication, preventing articles outside the desired scope (e.g., 'general' or 'mundo' when only 'tecnologia' is configured) from being published, as per your previous feedback.