### PR TITLE
fix: Align config.json category spelling with internal representation

### DIFF
--- a/config.json
+++ b/config.json
@@ -68,5 +68,5 @@
   "max_articles_homepage": 0,
   "recency_filter_hours": 24,
   "similarity_threshold": 0.6,
-  "allowed_publish_categories": ["tecnologia"]
+  "allowed_publish_categories": ["tecnología"]
 }


### PR DESCRIPTION
Corrects an issue where all articles were being skipped because of a mismatch in category string representation between `config.json` and internal application logic.

The `allowed_publish_categories` key in `config.json` previously used "tecnologia" (without an accent), while the `BlinkGenerator` and its `ALLOWED_CATEGORIES` list used "tecnología" (with an accent). This discrepancy caused the filtering check in `routes/api.py` to incorrectly determine that "tecnología" articles were not in the allowed list, leading to them being skipped.

This commit updates `config.json` to use "tecnología" (with the accent) in the `allowed_publish_categories` list, ensuring exact string matches and allowing correctly categorized articles to be published as intended.