### PR TITLE
Fix: News loading error by enabling API routes

### DIFF
--- a/news-blink-backend/src/app.py
+++ b/news-blink-backend/src/app.py
@@ -1,5 +1,5 @@
 from flask import Flask
-# from .routes.api import api_bp  # Commented out for now
+from .routes.api import api_bp  # Commented out for now
 from .routes.topic_search import topic_search_bp # Import the new blueprint
 from .config import Config
 
@@ -11,7 +11,7 @@ def create_app():
     app.config.from_object(Config)
 
     # Register blueprints
-    # app.register_blueprint(api_bp, url_prefix='/api') # Commented out
+    app.register_blueprint(api_bp, url_prefix='/api') # Commented out
     app.register_blueprint(topic_search_bp, url_prefix='/search') # Register the topic search blueprint
 
     return app

--- a/news-blink-backend/src/routes/api.py
+++ b/news-blink-backend/src/routes/api.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 # Create a Blueprint for API routes
 api_bp = Blueprint('api', __name__)
@@ -12,24 +12,24 @@ def health_check():
     return jsonify({"status": "ok"}), 200
 
 # TODO: Add other API routes here
-# from ..services.news_service import NewsService
-# from ..config import Config
-# news_service = NewsService(api_key=Config.NEWS_API_KEY)
-# @api_bp.route('/news', methods=['GET'])
-# def get_news():
-#     """
-#     Route to get news articles.
-#     It uses NewsService to fetch news based on query parameters.
-#     """
-#     # Parameters for fetching news, can be passed as query arguments
-#     params = {
-#         'country': request.args.get('country', default='us'),
-#         'category': request.args.get('category', default='general')
-#     }
-#     try:
-#         articles = news_service.get_news(**params)
-#         return jsonify(articles)
-#     except Exception as e:
-#         # Log the exception for debugging
-#         # current_app.logger.error(f"Error fetching news: {e}")
-#         return jsonify({"error": "Failed to fetch news"}), 500
+from ..services.news_service import NewsService
+from ..config import Config
+news_service = NewsService(api_key=Config.NEWS_API_KEY)
+@api_bp.route('/news', methods=['GET'])
+def get_news():
+    """
+    Route to get news articles.
+    It uses NewsService to fetch news based on query parameters.
+    """
+    # Parameters for fetching news, can be passed as query arguments
+    params = {
+        'country': request.args.get('country', default='us'),
+        'category': request.args.get('category', default='general')
+    }
+    try:
+        articles = news_service.get_news(**params)
+        return jsonify(articles)
+    except Exception as e:
+        # Log the exception for debugging
+        # current_app.logger.error(f"Error fetching news: {e}")
+        return jsonify({"error": "Failed to fetch news"}), 500


### PR DESCRIPTION
The API blueprint was not registered in the Flask app, and several parts of the API route for fetching news were commented out. This commit uncommented these parts to enable the `/api/news` route.

Specifically, this commit:
- Uncommented the registration of the `api_bp` blueprint in `news-blink-backend/src/app.py`.
- Uncommented the import of `api_bp` in `news-blink-backend/src/app.py`.
- Uncommented the imports for `NewsService` and `Config` in `news-blink-backend/src/routes/api.py`.
- Uncommented the `get_news` function, its decorator, and the `NewsService` instantiation in `news-blink-backend/src/routes/api.py`.
- Added `request` to the Flask imports in `news-blink-backend/src/routes/api.py`.