### PR TITLE
Fix: Correct frontend news filtering and data handling

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -33,7 +33,7 @@ export const useNewsFilter = (news: any[]) => {
       case 'rumores':
         filtered = filtered.filter(item => item.category === 'RUMORES' || item.aiScore < 90);
         break;
-      case 'ultima':
+      case 'ultimas':
         // Sort by date for recent news
         filtered = filtered.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
         break;
@@ -42,7 +42,7 @@ export const useNewsFilter = (news: any[]) => {
     }
 
     // Final sort by votes (except for "ultima" tab)
-    if (activeTab !== 'ultima') {
+    if (activeTab !== 'ultimas') {
       filtered = filtered.sort((a, b) => {
         const aVotes = (a.votes?.likes || 0) - (a.votes?.dislikes || 0);
         const bVotes = (b.votes?.likes || 0) - (b.votes?.dislikes || 0);

--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -16,7 +16,7 @@ export const useRealNews = () => {
       // Transform data to match our component structure
       const transformedNews = newsData.map(item => ({
         ...item,
-        category: item.category || 'TECNOLOGÍA',
+        category: (item.categories && item.categories.length > 0 ? item.categories[0] : 'TECNOLOGÍA'),
         isHot: item.isHot || (item.sources && item.sources.length > 2),
         readTime: item.readTime || '5 min',
         publishedAt: item.publishedAt || new Date().toISOString(),


### PR DESCRIPTION
This commit addresses two issues in the frontend hooks:

1.  **Typographical Error in `useNewsFilter.ts`**: Corrected `case 'ultima':` to `case 'ultimas':` and the condition `if (activeTab !== 'ultima')` to `if (activeTab !== 'ultimas')`. This ensures that the news items in the 'ultimas' (latest) tab are correctly sorted by their publication date.

2.  **Data Inconsistency in `useRealNews.ts`**: Modified the `transformedNews` mapping to correctly access `item.categories` (which is an array) instead of `item.category` (which was undefined). The code now uses the first category from the `categories` array, or defaults to 'TECNOLOGÍA' if the array is empty or undefined. This ensures categories are correctly assigned to news items.