### PR TITLE
Feat: Add detailed logging to frontend news fetching

### DIFF
--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -8,6 +8,7 @@ export const useRealNews = () => {
   const [error, setError] = useState<string | null>(null);
 
   const loadNews = async (tab: string = 'ultimas') => {
+    console.log('loadNews called with tab:', tab);
     setLoading(true);
     setError(null);
     
@@ -25,7 +26,7 @@ export const useRealNews = () => {
       
       setNews(transformedNews);
     } catch (err) {
-      console.error('Error al cargar noticias:', err);
+      console.error('Full error object in loadNews catch block:', err);
       setError('Error al cargar las noticias. Por favor, intente nuevamente más tarde.');
       // Fallback to empty array on error
       setNews([]);

--- a/news-blink-frontend/src/utils/api.ts
+++ b/news-blink-frontend/src/utils/api.ts
@@ -21,15 +21,19 @@ export interface NewsItem {
 }
 
 export const fetchNews = async (tab = 'ultimas'): Promise<NewsItem[]> => {
+  console.log('Fetching news with tab:', tab);
   try {
-    const response = await fetch(`${API_BASE_URL}/news?tab=${tab}`);
+    const url = `${API_BASE_URL}/news?tab=${tab}`;
+    console.log('Attempting to fetch from URL:', url);
+    const response = await fetch(url);
     if (!response.ok) {
+      console.error('Fetch failed with status:', response.status, response.statusText);
       throw new Error('Error al obtener noticias');
     }
     const data = await response.json();
     return data;
   } catch (error) {
-    console.error('Error fetching news:', error);
+    console.error('Full error object while fetching news:', error);
     throw error;
   }
 };


### PR DESCRIPTION
Added more detailed console logging to `fetchNews` in `utils/api.ts` and `loadNews` in `hooks/useRealNews.ts`. This will help you diagnose issues with news loading by providing more insight into:
- The exact URL being fetched.
- The response status and text if the fetch fails.
- The full error objects caught in both functions.