### PR TITLE
Fix: Correct Vite proxy path forwarding for API requests

### DIFF
--- a/news-blink-frontend/vite.config.ts
+++ b/news-blink-frontend/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig(({ mode }) => ({
       '/api': {
         target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:5000',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
Removed the `rewrite` rule from the `/api` proxy configuration in `news-blink-frontend/vite.config.ts`.

The previous rewrite rule (`path.replace(/^\/api/, '')`) was incorrectly stripping the `/api` prefix, causing the backend to receive a path like `/news` instead of the expected `/api/news`. This resulted in a 404 error from the backend.

By removing the rewrite, the proxy will now forward the path `/api/news` as is to the backend service, which is configured to handle routes under the `/api` prefix. This should resolve the 404 errors and allow the frontend to correctly fetch data from the backend API.