### PR TITLE
Fix: Adjust z-index for AnimatedBackground

### DIFF
--- a/news-blink-frontend/src/components/AnimatedBackground.tsx
+++ b/news-blink-frontend/src/components/AnimatedBackground.tsx
@@ -5,7 +5,7 @@ export const AnimatedBackground = () => {
   const { isDarkMode } = useTheme();
 
   return (
-    <div className="fixed inset-0 -z-10">
+    <div className="fixed inset-0 z-0">
       {/* Fondo base sólido - sin amarillo */}
       <div className={`absolute inset-0 ${isDarkMode ? 'bg-black' : 'bg-gray-50'}`} />
       


### PR DESCRIPTION
Changed the z-index of the AnimatedBackground component from -z-10 to z-0. This is an attempt to make the background visible, as the previous negative z-index might have placed it behind the default page background.