### PR TITLE
Integrate real BLINK news API into frontend

### DIFF
--- a/news-blink-frontend/src/App.tsx
+++ b/news-blink-frontend/src/App.tsx
@@ -4,7 +4,9 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import React, { useEffect, useState } from 'react';
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import { useRealNews } from './hooks/useRealNews';
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import BlinkDetail from "./pages/BlinkDetail";
@@ -12,26 +14,59 @@ import TopicSearch from "./pages/TopicSearch";
 
 const queryClient = new QueryClient();
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <ThemeProvider>
-      <TooltipProvider>
-        <div className="min-h-screen bg-background">
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/topic-search" element={<TopicSearch />} />
-              <Route path="/blink/:id" element={<BlinkDetail />} />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
-        </div>
-      </TooltipProvider>
-    </ThemeProvider>
-  </QueryClientProvider>
-);
+const App = () => {
+  const { news, loading, error, loadNews, refreshNews } = useRealNews();
+  const [currentTab, setCurrentTab] = useState('ultimas');
+
+  useEffect(() => {
+    loadNews(currentTab);
+  }, [currentTab, loadNews]);
+
+  useEffect(() => {
+    console.log("News Data:", news);
+    console.log("Loading State:", loading);
+    console.log("Error State:", error);
+  }, [news, loading, error]);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <TooltipProvider>
+          <div className="min-h-screen bg-background">
+            <Toaster />
+            <Sonner />
+
+            {/* Test UI for useRealNews hook */}
+            <div style={{ padding: '20px', borderBottom: '1px solid #ccc' }}>
+              <h1>News Blink App - Test Logging</h1>
+              <div>
+                <button onClick={() => setCurrentTab('ultimas')} style={{ marginRight: '10px' }}>Ultimas</button>
+                <button onClick={() => setCurrentTab('tendencias')} style={{ marginRight: '10px' }}>Tendencias</button>
+                <button onClick={() => setCurrentTab('rumores')} style={{ marginRight: '10px' }}>Rumores</button>
+                <button onClick={() => refreshNews(currentTab)}>Refresh Current Tab</button>
+              </div>
+              {loading && <p>Loading news...</p>}
+              {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+              <pre style={{ maxHeight: '300px', overflowY: 'auto', background: '#f0f0f0', padding: '10px', marginTop: '10px' }}>
+                {JSON.stringify(news, null, 2)}
+              </pre>
+            </div>
+            {/* End Test UI */}
+
+            <BrowserRouter>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/topic-search" element={<TopicSearch />} />
+                <Route path="/blink/:id" element={<BlinkDetail />} />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </BrowserRouter>
+          </div>
+        </TooltipProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+};
 
 export default App;

--- a/news-blink-frontend/src/utils/api.ts
+++ b/news-blink-frontend/src/utils/api.ts
@@ -20,33 +20,8 @@ export interface NewsItem {
 
 // Mock API functions using local data
 export const fetchNews = async (tab: string = 'ultimas'): Promise<NewsItem[]> => {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 300));
-  
-  let filteredNews = [...mockNews];
-  
-  switch (tab) {
-    case 'tendencias':
-      filteredNews = mockNews.filter(item => item.isHot || item.aiScore > 85);
-      break;
-    case 'rumores':
-      filteredNews = mockNews.filter(item => item.category === 'RUMORES' || item.aiScore < 90);
-      break;
-    case 'ultimas':
-    default:
-      filteredNews = mockNews.sort((a, b) => 
-        new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
-      );
-      break;
-  }
-  
-  // Ensure all news items have required properties
-  return filteredNews.map(item => ({
-    ...item,
-    isHot: item.isHot || false,
-    votes: item.votes || { likes: 0, dislikes: 0 },
-    sources: item.sources || []
-  }));
+  console.warn("fetchNews in api.ts is deprecated. Please use the useRealNews hook for fetching news lists.");
+  return Promise.resolve([]);
 };
 
 export const voteOnArticle = async (articleId: string, voteType: 'like' | 'dislike'): Promise<void> => {


### PR DESCRIPTION
- I replaced mock news data in `useRealNews.ts` with calls to the backend `/api/news` endpoint.
- I implemented data transformation to map backend response to the frontend `NewsItem` interface, including default values for fields not provided by the API.
- I deprecated `fetchNews` in `utils/api.ts`, directing usage to `useRealNews`.
- Functions `fetchArticleById` and `searchNewsByTopic` in `utils/api.ts` remain mocked pending backend support.
- I added temporary logging and interactive elements in `App.tsx` to aid in testing the integration.