### PR TITLE
Fix: Configure Vite proxy for API requests

### DIFF
--- a/news-blink-frontend/vite.config.ts
+++ b/news-blink-frontend/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      }
+    }
   },
   plugins: [
     react(),


### PR DESCRIPTION
I added a server proxy configuration to `vite.config.ts` to ensure that API requests you make from the frontend (prefixed with `/api`) are correctly forwarded to the backend server. This addresses an issue where the frontend was receiving HTML instead of JSON due to misrouted API calls.