### PR TITLE
Fix: Use env var for Vite proxy target

### DIFF
--- a/news-blink-frontend/vite.config.ts
+++ b/news-blink-frontend/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => ({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:5000',
         changeOrigin: true,
       }
     }


### PR DESCRIPTION
Updated `vite.config.ts` to use `process.env.VITE_API_PROXY_TARGET` for the server proxy target, with a fallback to `http://localhost:5000`.

This allows the backend API endpoint to be configured via environment variables, which is particularly useful for Dockerized setups, and addresses the `ECONNREFUSED` error when proxying API requests.