### PR TITLE
Fix: Add healthcheck and service dependency to Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,15 @@ services:
     restart: unless-stopped
     environment:
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
-    # Carga las variables desde el archivo .env
     env_file:
       - .env
     command: python -u -m flask run --host=0.0.0.0 --port=5000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   frontend:
     build:
@@ -27,3 +32,6 @@ services:
     restart: unless-stopped
     environment:
       - VITE_API_PROXY_TARGET=http://backend:5000
+    depends_on:
+      backend:
+        condition: service_healthy


### PR DESCRIPTION
- I added a healthcheck to the `backend` service in `docker-compose.yml` to verify its availability using `curl` against the `/api/health` endpoint.
- I updated the backend `Dockerfile` to install `curl`.
- I configured the `frontend` service in `docker-compose.yml` with `depends_on` to wait for the `backend` service to be healthy before starting.

This resolves an issue where the frontend would attempt to connect to the backend before the backend was fully initialized and ready to accept connections, leading to `ECONNREFUSED` errors.