### PR TITLE
Fix: Update backend config to allow more news categories

### DIFF
--- a/config.json
+++ b/config.json
@@ -68,5 +68,5 @@
   "max_articles_homepage": 0,
   "recency_filter_hours": 24,
   "similarity_threshold": 0.6,
-  "allowed_publish_categories": ["tecnología"]
+  "allowed_publish_categories": ["tecnología", "general", "science"]
 }


### PR DESCRIPTION
I modified `config.json` to add 'general' and 'science' to the `allowed_publish_categories` list.

This is to test if the backend NewsService will now return articles when these categories are requested by the frontend, potentially resolving the issue of no news being displayed.