### PR TITLE
Feat: Change default frontend news request to 'technology' category

### DIFF
--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -40,7 +40,7 @@ export const useRealNews = () => {
         break;
       case 'ultimas':
       default:
-        apiCategory = 'general';
+        apiCategory = 'technology'; // Changed from 'general' to 'technology'
         break;
     }
 


### PR DESCRIPTION
I modified `useRealNews.ts` so that the 'ultimas' (latest news) tab now requests the 'technology' category from the backend API instead of 'general'.

This change is to align the frontend request with the backend's configured `allowed_publish_categories` which includes 'tecnología' (assumed to map to 'technology'), in an attempt to get news data to display in your UI.