### PR TITLE
Fix: Articles not displaying on homepage

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -33,7 +33,7 @@ export const useNewsFilter = (news: any[]) => {
       case 'rumores':
         filtered = filtered.filter(item => item.category === 'RUMORES' || item.aiScore < 90);
         break;
-      case 'ultima':
+      case 'ultimas':
         // Sort by date for recent news
         filtered = filtered.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
         break;
@@ -41,8 +41,8 @@ export const useNewsFilter = (news: any[]) => {
         break;
     }
 
-    // Final sort by votes (except for "ultima" tab)
-    if (activeTab !== 'ultima') {
+    // Final sort by votes (except for "ultimas" tab)
+    if (activeTab !== 'ultimas') {
       filtered = filtered.sort((a, b) => {
         const aVotes = (a.votes?.likes || 0) - (a.votes?.dislikes || 0);
         const bVotes = (b.votes?.likes || 0) - (b.votes?.dislikes || 0);


### PR DESCRIPTION
The homepage was showing "Sin resultados" due to a mismatch in initial data loading and filtering logic.

Key changes:
- Modified `Index.tsx` to correctly initialize the `activeTab` to 'ultimas'. This ensures that the initial news load for 'ultimas' is processed by `useNewsFilter` with the corresponding 'ultimas' filter logic (which sorts by date).
- Standardized tab identifier to 'ultimas' in `useNewsFilter.ts` and `Index.tsx`.
- Enhanced `useRealNews.ts`:
    - Data transformation now correctly sources `isHot` and `aiScore` fields from the API if available, instead of hardcoding them. This allows 'tendencias' and other filters to work as intended if the backend provides these values.
    - Improved error message handling to provide more specific and user-friendly feedback by attempting to parse error details from API responses.
    - Added more detailed console logging for API request failures to aid developers.

These changes ensure that articles fetched for the initial view are displayed correctly and that error reporting is more informative.