### PR TITLE
Fix: Align frontend API category parameter with backend

### DIFF
--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -33,14 +33,14 @@ export const useRealNews = () => {
 
     switch (tab) {
       case 'tendencias':
-        apiCategory = 'technology';
+        apiCategory = 'tecnología'; // Changed from 'technology'
         break;
       case 'rumores':
-        apiCategory = 'science';
+        apiCategory = 'science'; // Remains 'science'
         break;
       case 'ultimas':
       default:
-        apiCategory = 'technology'; // Changed from 'general' to 'technology'
+        apiCategory = 'tecnología'; // Changed from 'technology'
         break;
     }
 


### PR DESCRIPTION
Changed the category parameter sent from the frontend to the backend from 'technology' to 'tecnología'.

The backend expects 'tecnología' as per its configuration and logs, and was returning an empty array when 'technology' was used. This change ensures the frontend uses the correct category name in API requests to fetch news articles.

- Modified `news-blink-frontend/src/hooks/useRealNews.ts` to set `apiCategory` to 'tecnología' for 'ultimas' and 'tendencias' tabs.