### PR TITLE
Fix: Correctly initialize activeTab in useNewsFilter

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -1,12 +1,12 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 
-export const useNewsFilter = (news: any[]) => {
+export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencias') => {
   console.log('[useNewsFilter] Hook called/re-rendered. Input news length:', news.length, 'First item if exists:', news.length > 0 ? news[0] : 'N/A');
   const [filteredNews, setFilteredNews] = useState<any[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
-  const [activeTab, setActiveTab] = useState('tendencias');
+  const [activeTab, setActiveTab] = useState(initialActiveTab);
 
   // Memoize expensive computations
   const searchFilteredNews = useMemo(() => {


### PR DESCRIPTION
I modified useNewsFilter to accept an initialActiveTab parameter, and updated Index.tsx to pass 'ultimas' as this initial value. This ensures that the filtering logic uses the correct 'ultimas' tab setting from the very first render when news data arrives, preventing the 'tendencias' filter from incorrectly emptying the news list.

- I changed useNewsFilter.ts to accept initialActiveTab.
- I updated Index.tsx to provide initialActiveTab to useNewsFilter.
- I removed the useEffect in Index.tsx that previously set activeTab.

This addresses the issue where filteredNews was empty due to stale activeTab state during memoization. Diagnostic logs remain for now.