### PR TITLE
Fix: Ensure correct initial activeTab and news loading sequence

### DIFF
--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -22,7 +22,7 @@ const Index = () => {
     activeTab,
     setActiveTab,
     clearFilters
-  } = useNewsFilter(news);
+  } = useNewsFilter(news, 'ultimas');
 
   // Add this new log statement:
   console.log(
@@ -36,13 +36,16 @@ const Index = () => {
 
   const [heroNews, setHeroNews] = useState(null);
 
-  useEffect(() => {
-    loadNews('ultimas');
-  }, []);
+  // REMOVED:
+  // useEffect(() => {
+  //   loadNews('ultimas');
+  // }, []);
 
   useEffect(() => {
-    loadNews(activeTab);
-  }, [activeTab]);
+    if (activeTab) { // Ensure activeTab is truthy before loading
+      loadNews(activeTab);
+    }
+  }, [activeTab, loadNews]); // loadNews is from useRealNews
 
   useEffect(() => {
     if (filteredNews.length > 0) {


### PR DESCRIPTION
This commit addresses the core issue where articles were not displaying despite data being fetched. The `useNewsFilter` hook was incorrectly using 'tendencias' as its active tab during critical render cycles.

Changes:
1.  **useNewsFilter.ts**:
    *   Modified to accept an `initialActiveTab` prop, defaulting
      to 'tendencias' if not provided. The `activeTab` state is
      initialized with this prop.

2.  **Index.tsx**:
    *   Now calls `useNewsFilter(news, 'ultimas')`, correctly passing
      'ultimas' as the `initialActiveTab`.
    *   Removed a redundant `useEffect` that called `loadNews('ultimas')`
      directly on mount. The primary `useEffect` dependent on `activeTab`
      (which is now correctly 'ultimas' from the start) handles the
      initial news load.

This ensures that `useNewsFilter` starts with the correct `activeTab` ('ultimas'), leading to proper filtering and display of news articles from the initial API fetch. Diagnostic logs remain in place for the upcoming validation.