### PR TITLE
Fix: Correct image URL source in useRealNews transformation

### DIFF
--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -110,7 +110,7 @@ export const useRealNews = () => {
         return {
           id: article.url || `news-${index}`,
           title: article.title || 'No Title',
-          image: article.urlToImage || 'https://via.placeholder.com/800x600.png?text=No+Image',
+          image: (typeof article.image === 'string' && article.image.trim() !== '') ? article.image.trim() : 'https://via.placeholder.com/800x600.png?text=No+Image',
           points: newPoints,
           category: apiCategory,
           isHot: typeof article.isHot === 'boolean' ? article.isHot : false,


### PR DESCRIPTION
Updated the data transformation logic in useRealNews.ts for the 'image' field of news articles.

The transformation now uses `article.image` from the raw API data instead of `article.urlToImage`, as logs indicated the image URL is provided under the `image` key.

A check is in place to ensure `article.image` is a non-empty string; otherwise, it falls back to the standard placeholder image. This should resolve issues where images were not loading because the wrong field was being accessed.