### PR TITLE
Chore: Remove diagnostic console.log statements

### DIFF
--- a/news-blink-frontend/src/components/NewsContent.tsx
+++ b/news-blink-frontend/src/components/NewsContent.tsx
@@ -37,28 +37,11 @@ export const NewsContent = ({
 }: NewsContentProps) => {
   const { isDarkMode } = useTheme();
 
-  console.log('[NewsContent] Props received:', {
-    loading,
-    filteredNewsLength: filteredNews.length,
-    // Optional: log first item to verify data structure if needed
-    // filteredNewsFirstItem: filteredNews.length > 0 ? filteredNews[0] : 'N/A',
-    heroNewsExists: !!heroNews,
-    searchTerm,
-    selectedCategory,
-    activeTab
-  });
-
   if (loading) {
-    console.log('[NewsContent] Rendering LoadingState because loading is true.');
     return <LoadingState />;
   }
 
   if (filteredNews.length === 0) {
-    if (searchTerm || selectedCategory !== 'all') {
-      console.log('[NewsContent] Rendering EmptyState because filteredNews is empty AND search/category filters ARE active.');
-    } else {
-      console.log('[NewsContent] Rendering EmptyState because filteredNews is empty AND no search/category filters are active.');
-    }
     return (
       <>
         <IntegratedNavigationBar
@@ -75,8 +58,6 @@ export const NewsContent = ({
     );
   }
 
-  // If we reach here, filteredNews.length > 0
-  console.log(`[NewsContent] Conditions met to render main content with NewsGrid. Filtered news length: ${filteredNews.length}`);
   return (
     <div className="space-y-12">
       {heroNews && (
@@ -135,7 +116,7 @@ export const NewsContent = ({
         Let's add a log for the case where filteredNews.length is 1 and heroNews is present, so "Más Noticias" is skipped.
       */}
       {heroNews && filteredNews.length === 1 && (
-        console.log('[NewsContent] Rendering main content with HeroNews only (filteredNews.length is 1). No "Más Noticias" grid.')
+        null /* Was: console.log('[NewsContent] Rendering main content with HeroNews only (filteredNews.length is 1). No "Más Noticias" grid.') */
       )}
       {!heroNews && filteredNews.length > 0 && (
          // This case is not explicitly handled by the current NewsGrid rendering logic if heroNews is null.
@@ -143,7 +124,7 @@ export const NewsContent = ({
          // The current NewsGrid is only for filteredNews.slice(1).
          // This indicates a potential area for future code improvement if heroNews can be null while filteredNews is not empty.
          // For now, logging the observation.
-        console.log('[NewsContent] Rendering main content. heroNews is not present, but filteredNews has items. NewsGrid will show filteredNews.slice(1).')
+         null /* Was: console.log('[NewsContent] Rendering main content. heroNews is not present, but filteredNews has items. NewsGrid will show filteredNews.slice(1).') */
       )}
 
     </div>

--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -4,12 +4,6 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencias') => { // Keep the signature allowing initialActiveTab
   const [activeTab, setActiveTab] = useState(initialActiveTab);
 
-  // THIS IS THE CRUCIAL LOG - ensuring it's exactly this:
-  console.log(
-    '[useNewsFilter] Hook called/re-rendered. Received initialActiveTab:', initialActiveTab,
-    '. Current internal activeTab state (from useState):', activeTab,
-    '. Input news length:', news.length
-  );
   const [filteredNews, setFilteredNews] = useState<any[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
@@ -24,13 +18,11 @@ export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencia
       (item.points && item.points.some((point: string) => point.toLowerCase().includes(lowercaseSearch)))
     );
   }, [news, searchTerm]);
-  console.log('[useNewsFilter] searchFilteredNews computed. Length:', searchFilteredNews.length, 'ActiveSearchTerm:', searchTerm, 'First item:', searchFilteredNews.length > 0 ? searchFilteredNews[0] : 'N/A');
 
   const categoryFilteredNews = useMemo(() => {
     if (selectedCategory === 'all') return searchFilteredNews;
     return searchFilteredNews.filter(item => item.category === selectedCategory);
   }, [searchFilteredNews, selectedCategory]);
-  console.log('[useNewsFilter] categoryFilteredNews computed. Length:', categoryFilteredNews.length, 'SelectedCategory:', selectedCategory, 'First item:', categoryFilteredNews.length > 0 ? categoryFilteredNews[0] : 'N/A');
 
   const tabFilteredNews = useMemo(() => {
     let filtered = [...categoryFilteredNews];
@@ -61,10 +53,8 @@ export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencia
 
     return filtered;
   }, [categoryFilteredNews, activeTab]);
-  console.log('[useNewsFilter] tabFilteredNews (variable from useMemo) computed. Length:', tabFilteredNews.length, 'ActiveTab:', activeTab, 'First item:', tabFilteredNews.length > 0 ? tabFilteredNews[0] : 'N/A');
 
   useEffect(() => {
-    console.log('[useNewsFilter] useEffect for tabFilteredNews. tabFilteredNews length:', tabFilteredNews.length, 'First item if exists:', tabFilteredNews.length > 0 ? tabFilteredNews[0] : 'N/A');
     setFilteredNews(tabFilteredNews);
   }, [tabFilteredNews]);
 

--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -79,15 +79,6 @@ export const useRealNews = () => {
       }
       const data = await response.json();
 
-      console.log('[useRealNews] Raw data received from API:', JSON.stringify(data, null, 2));
-      console.log('[useRealNews] Is raw data an array?', Array.isArray(data));
-      if (Array.isArray(data)) {
-        console.log('[useRealNews] Raw data array length:', data.length);
-        if (data.length > 0) {
-          console.log('[useRealNews] First item of raw data:', JSON.stringify(data[0], null, 2));
-        }
-      }
-
       if (!Array.isArray(data)) {
         console.error('[useRealNews] API response is not an array:', data);
         // Consider if data might be an object with an error message from the API
@@ -122,11 +113,6 @@ export const useRealNews = () => {
         };
       });
       
-      console.log('[useRealNews] Transformed news data length:', transformedNews.length);
-      if (transformedNews.length > 0) {
-        console.log('[useRealNews] First item of transformed news:', JSON.stringify(transformedNews[0], null, 2));
-      }
-
       setNews(transformedNews);
     } catch (err: any) {
       console.error('[useRealNews] Error in loadNews catch block:', err.message);

--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -24,16 +24,6 @@ const Index = () => {
     clearFilters
   } = useNewsFilter(news, 'ultimas');
 
-  // Add this new log statement:
-  console.log(
-    '[Index.tsx] Value from useNewsFilter hook. filteredNews.length:',
-    filteredNews.length,
-    'First item if exists:',
-    filteredNews.length > 0 ? filteredNews[0] : 'N/A',
-    'loading state:', loading, // also log loading state from useRealNews
-    'activeTab from useNewsFilter:', activeTab // also log activeTab
-  );
-
   const [heroNews, setHeroNews] = useState(null);
 
   // REMOVED:


### PR DESCRIPTION
I've removed temporary console.log statements that were added during debugging of the article display and data flow issues.

Logs were removed from:
- news-blink-frontend/src/hooks/useRealNews.ts
- news-blink-frontend/src/hooks/useNewsFilter.ts
- news-blink-frontend/src/pages/Index.tsx
- news-blink-frontend/src/components/NewsContent.tsx

This cleans up the codebase after the successful resolution of the display issues.