### PR TITLE
Fix: Add /search path to Vite proxy configuration

### DIFF
--- a/news-blink-frontend/vite.config.ts
+++ b/news-blink-frontend/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig(({ mode }) => ({
       '/api': {
         target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:5000',
         changeOrigin: true,
+      },
+      '/search': { // New entry
+        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:5000',
+        changeOrigin: true,
       }
     }
   },


### PR DESCRIPTION
I've updated news-blink-frontend/vite.config.ts to include a proxy rule for requests made to `/search/...`. This ensures that API calls to the backend's advanced topic search endpoints (e.g., /search/start_topic_search) are correctly forwarded by the Vite development server.

This resolves the 404 errors you previously encountered when attempting to use the advanced topic search feature from the frontend.