### PR TITLE
Chore: Enable Flask debug mode for backend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     restart: unless-stopped
     environment:
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - FLASK_DEBUG=1
     env_file:
       - .env
     command: python -u -m flask run --host=0.0.0.0 --port=5000


### PR DESCRIPTION
I modified docker-compose.yml to set the FLASK_DEBUG=1 environment variable for the backend service.

This enables Flask's debug mode, which provides:
- Detailed error pages for easier debugging.
- Automatic reloader to pick up code changes without manual restarts.

This should help in diagnosing route registration issues and improve the development feedback loop.