### PR TITLE
Here's a fix to resolve the "Artículo no encontrado" error you were s…

### DIFF
--- a/news-blink-frontend/src/utils/api.ts
+++ b/news-blink-frontend/src/utils/api.ts
@@ -56,16 +56,80 @@ export const voteOnArticle = async (articleId: string, voteType: 'like' | 'disli
 };
 
 export const fetchArticleById = async (id: string): Promise<NewsItem | null> => {
-  await new Promise(resolve => setTimeout(resolve, 200));
-  const item = mockNews.find(item => item.id === id);
-  if (!item) return null;
-  
-  return {
-    ...item,
-    isHot: item.isHot || false,
-    votes: item.votes || { likes: 0, dislikes: 0 },
-    sources: item.sources || []
-  };
+  const newsIdRegex = /^news-\d+$/;
+
+  if (newsIdRegex.test(id)) {
+    // New logic: Fetch from API
+    try {
+      const response = await fetch('/api/news?country=us&category=tecnología');
+      if (!response.ok) {
+        console.error(`API error: ${response.status} ${response.statusText}`);
+        return null;
+      }
+      const articlesFromApi = await response.json();
+
+      if (!Array.isArray(articlesFromApi)) {
+        console.error('API error: Response is not an array');
+        return null;
+      }
+
+      let foundArticle: NewsItem | null = null;
+
+      for (let i = 0; i < articlesFromApi.length; i++) {
+        const apiArticle = articlesFromApi[i];
+        const generatedId = apiArticle.url || `news-${i}`;
+
+        if (generatedId === id) {
+          // Assuming apiArticle has a structure compatible with NewsItem
+          // and only needs default values for optional fields.
+          foundArticle = {
+            // Default NewsItem structure, ensure all fields are present
+            title: apiArticle.title || 'Untitled',
+            image: apiArticle.image || '',
+            points: apiArticle.points || [],
+            category: apiArticle.category || 'General',
+            readTime: apiArticle.readTime || 'N/A',
+            publishedAt: apiArticle.publishedAt || new Date().toISOString(),
+            aiScore: apiArticle.aiScore || 0,
+            // Overwrite with generated/matched id
+            id: generatedId,
+            // Ensure these potentially missing fields are initialized
+            isHot: apiArticle.isHot || false,
+            votes: apiArticle.votes || { likes: 0, dislikes: 0 },
+            sources: apiArticle.sources || [],
+            // Spread any other properties from apiArticle
+            ...apiArticle,
+          };
+          break;
+        }
+      }
+
+      if (!foundArticle) {
+        console.error(`Article with id ${id} not found in API response.`);
+        return null;
+      }
+      return foundArticle;
+
+    } catch (error) {
+      console.error('Failed to fetch article by ID from API:', error);
+      return null;
+    }
+  } else {
+    // Existing logic: Find in mockNews
+    await new Promise(resolve => setTimeout(resolve, 200)); // Keep simulated delay for mock path
+    const item = mockNews.find(item => item.id === id);
+    if (!item) {
+      console.log(`Article with id ${id} not found in mockNews.`);
+      return null;
+    }
+
+    return {
+      ...item,
+      isHot: item.isHot || false,
+      votes: item.votes || { likes: 0, dislikes: 0 },
+      sources: item.sources || []
+    };
+  }
 };
 
 export const searchNewsByTopic = async (topic: string): Promise<NewsItem[]> => {


### PR DESCRIPTION
…eeing for BLINKs with API-generated IDs.

Previously, when a news item from the backend API didn't have a 'url' property, its ID was being generated as 'news-[index]' (for example, 'news-0').

When you navigated to the detail page for such an item (like /blink/news-0), the 'BlinkDetail.tsx' component would try to load the article using 'fetchArticleById'. However, 'fetchArticleById' was only looking for articles in 'mockData.ts', which uses different ID formats (like "1", "2"). This mismatch caused the "Artículo no encontrado" error.

I've now modified 'fetchArticleById' in 'utils/api.ts':
- If the article ID matches the 'news-\d+' pattern, the function will now fetch the full list of news from the '/api/news' endpoint.
- It then transforms this list (including the 'news-[index]' ID generation logic) and finds the specific article by its ID.
- If the ID doesn't match the pattern, it will fall back to the previous behavior of looking up the article in 'mockData.ts'.

This ensures that 'BlinkDetail.tsx' can correctly load article data regardless of whether the ID comes from a backend-fetched item or from the mock dataset.