### PR TITLE
Fix: Display full article content in detail view

### DIFF
--- a/news-blink-frontend/src/pages/BlinkDetail.tsx
+++ b/news-blink-frontend/src/pages/BlinkDetail.tsx
@@ -88,7 +88,7 @@ export default function BlinkDetail() {
               />
 
               <div className="prose prose-lg max-w-none">
-                <ArticleContent />
+                <ArticleContent articleContent={article?.content} />
               </div>
 
               {article.sources && article.sources.length > 0 && (


### PR DESCRIPTION
This commit ensures that the full article content is correctly displayed on the article detail page, resolving the 'Contenido no disponible' issue.

Changes included:
- Modified `BlinkDetail.tsx` to pass the `article.content` (fetched from the `/api/article/:id` endpoint) to the `ArticleContent` component.
- Previous related changes (already part of the history leading to this):
    - `NewsItem` interface updated with `content?: string`.
    - `ArticleContent.tsx` updated to render dynamic content.
    - `useRealNews.ts` and `fetchArticleById.ts` updated to correctly handle article IDs and fetch/map the `content` field.

With this change, the main text body of articles should now be visible. Further work will focus on refining the AI-generated content structure to include specific elements like quotes and formatted key conclusions as per your feedback by investigating the backend generation models.