### PR TITLE
Fix: Add react-markdown to frontend dependencies

### DIFF
--- a/news-blink-frontend/package.json
+++ b/news-blink-frontend/package.json
@@ -52,6 +52,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",


### PR DESCRIPTION
I've added `react-markdown` (^9.0.1) to the `dependencies` in `news-blink-frontend/package.json`.

This is required by the `ArticleContent.tsx` component to render Markdown content fetched from the backend. This explicit addition ensures that the frontend build process (e.g., `pnpm install` within Docker) can correctly install the dependency.