### PR TITLE
Fix(frontend): Handle API 'processing' status in useRealNews hook

### DIFF
--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -80,6 +80,14 @@ export const useRealNews = () => {
       }
       const data = await response.json();
 
+      // Handle specific "processing" status object response from API
+      if (!Array.isArray(data) && typeof data === 'object' && data !== null && data.status === 'processing') {
+        setNews([]);
+        setError((data as any).message || 'El backend está procesando noticias. Por favor, actualice en unos momentos.');
+        setLoading(false); // Processing isn't an error state for loading, but a message state
+        return; // Exit the function, news processing is pending
+      }
+
       if (!Array.isArray(data)) {
         console.error('[useRealNews] API response is not an array:', data);
         // Consider if data might be an object with an error message from the API


### PR DESCRIPTION
I modified the `useRealNews.ts` hook to correctly handle cases where the `/api/news` endpoint returns an object with `{"status": "processing"}` (e.g., when blinks are being generated for the first time after data clear).

Previously, the hook strictly expected a JSON array and would throw an 'Invalid data format' error if it received this status object.

The hook now:
- Checks for this specific status object.
- If detected, sets an appropriate error/status message for your UI (using the message from the API if provided).
- Clears the current news list and avoids attempting to process the object as an array.

This prevents the frontend error and provides better feedback to you during the backend's initial data generation phase.