### PR TITLE
Feat: Make AI tasks configurable via config.json

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -284,9 +284,11 @@ def schedule_news_collection(app):
 # Función para inicializar las rutas de la API
 def init_api(app):
     global scraper # Para modificar la instancia global del scraper
+    global blink_generator # Para modificar la instancia global del blink_generator
 
     app_config = app.config.get('APP_CONFIG', {})
     scraper = NewsScraper(app_config) # Inicializar con la configuración de la app
+    blink_generator = BlinkGenerator(app_config=app_config) # Re-inicializar con la configuración de la app
 
     app.register_blueprint(api_bp, url_prefix='/api')
     


### PR DESCRIPTION
I've modified `models/blink_generator.py` to allow the AI model name, input character limits, and temperature to be configured per AI task (determine_category, verify_category, generate_summary_points, format_main_content).

- `BlinkGenerator.__init__` now accepts an `app_config` and reads an `ai_task_configs` section from it, with fallbacks to sensible default values.
- Each AI-calling method in `BlinkGenerator` now uses the specific model, input_max_chars, and temperature defined for it in the configuration.
- I've updated `routes/api.py` to pass the `APP_CONFIG` to the `BlinkGenerator` instance during initialization.

This allows you to fine-tune AI behavior, test different models, and manage input lengths for each task to balance performance and quality, directly through `config.json`.