### PR TITLE
Fix JSON syntax error in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -63,7 +63,7 @@
       "summary_selector": "p",
       "category": "tecnologia"
     }
-  ],
+  ]
   "default_articles_per_source": 8,
   "max_articles_homepage": 0,
   "recency_filter_hours": 24,


### PR DESCRIPTION
A trailing comma after the 'news_sources' array was causing a JSON parsing error ("Extra data: line 2 column 17 (char 17)"). This prevented your application from loading its configuration correctly.

This commit removes the extraneous trailing comma, allowing `config.json` to be parsed successfully.