### PR TITLE
Fix missing comma in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -63,7 +63,7 @@
       "summary_selector": "p",
       "category": "tecnologia"
     }
-  ]
+  ],
   "default_articles_per_source": 8,
   "max_articles_homepage": 0,
   "recency_filter_hours": 24,


### PR DESCRIPTION
This commit addresses a JSON parsing error "Expecting ',' delimiter" in `config.json`. A comma was missing between the 'news_sources' array value and the 'default_articles_per_source' key-value pair.

This commit adds the required comma, ensuring the JSON is syntactically correct and can be parsed by the application.