### PR TITLE
Add detailed logging and increase Ollama timeout for AI tasks

### DIFF
--- a/config.json
+++ b/config.json
@@ -70,7 +70,7 @@
   "similarity_threshold": 0.6,
   "allowed_publish_categories": ["tecnología", "general", "science"],
   "default_ollama_model_name": "qwen3:32b",
-  "ollama_client_timeout": 90,
+  "ollama_client_timeout": 300,
   "ai_task_configs": {
     "determine_category": {
       "model_name": "llama3:latest",


### PR DESCRIPTION
This commit introduces changes to help diagnose issues with AI-powered content generation:

1.  **Detailed Logging:**
    - Added extensive debug logging to `generate_ollama_summary` and `format_content_with_ai` methods in `models/blink_generator.py`.
    - Logs now include input text snippets, full prompts sent to Ollama, raw Ollama responses, and more specific error details.

2.  **Increased Ollama Timeout:**
    - Modified `config.json` to increase `ollama_client_timeout` from 90 to 300 seconds. This is to provide more time for Ollama models to load and respond, addressing potential timeout errors.

These changes are intended to facilitate better debugging of AI content generation issues, particularly summary creation and article formatting.