### PR TITLE
Disable Flask auto-reloader in Docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD ["python", "-u", "-m", "flask", "run", "--host=0.0.0.0", "--port=5000"]
+CMD ["python", "-u", "-m", "flask", "run", "--host=0.0.0.0", "--port=5000", "--no-reload"]


### PR DESCRIPTION
I modified the CMD instruction in the Dockerfile to add the `--no-reload` option to the `flask run` command.

This ensures the Flask development server starts without the auto-reloader, providing a more stable environment for debugging long-running AI tasks by preventing interruptions and task duplication caused by reloads.