### PR TITLE
Fully disable Flask auto-reloader for stable execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY . .
 
 EXPOSE 5000
 
-CMD ["python", "-u", "-m", "flask", "run", "--host=0.0.0.0", "--port=5000", "--no-reload"]
+CMD ["python", "-u", "/app/app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,10 @@ services:
     restart: unless-stopped
     environment:
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
-      - FLASK_DEBUG=1
+      # - FLASK_DEBUG=1
     env_file:
       - .env
-    command: python -u -m flask run --host=0.0.0.0 --port=5000
+    # command: python -u -m flask run --host=0.0.0.0 --port=5000
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
       interval: 10s


### PR DESCRIPTION
This commit ensures the Flask auto-reloader is disabled to provide a stable environment for debugging AI tasks.

Changes include:
1.  Dockerfile: Modified `CMD` to execute `python /app/app.py` directly, allowing `use_reloader=False` in `app.py` to take effect.
2.  docker-compose.yml:
    - Commented out the `FLASK_DEBUG=1` environment variable for the backend service, as this can implicitly enable the reloader.
    - Commented out the explicit `command` for the backend service, so that the `CMD` from the Dockerfile is used.

These changes collectively aim to prevent multiple initializations and interruptions of the application by the auto-reloader during development.