### PR TITLE
Feat: Add @tailwindcss/typography plugin

### DIFF
--- a/news-blink-frontend/tailwind.config.ts
+++ b/news-blink-frontend/tailwind.config.ts
@@ -97,5 +97,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [require("tailwindcss-animate"), require('@tailwindcss/typography')],
 } satisfies Config;


### PR DESCRIPTION
I've added the @tailwindcss/typography plugin to the frontend's tailwind.config.ts file. This is necessary to enable the Tailwind `prose` classes, which are used to style
Markdown content in ArticleContent.tsx.

This change aims to fix the issue where Markdown content was displayed without proper styling in the frontend.