### PR TITLE
Style: Customize prose for quotes and conclusions

### DIFF
--- a/news-blink-frontend/src/index.css
+++ b/news-blink-frontend/src/index.css
@@ -1,4 +1,3 @@
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -138,4 +137,27 @@
 .dark .bg-yellow-400,
 .dark .bg-yellow-500 {
   background-color: black !important;
+}
+
+/* Custom styles for Conclusions Key block */
+.prose h2 + ul,
+.prose-lg h2 + ul { /* Targeting ul immediately following an h2 within prose scope */
+  background-color: hsl(215, 100%, 95%); /* customLightBlue.DEFAULT */
+  padding: 1rem; /* Adjust padding as needed */
+  border-radius: 0.5rem; /* var(--radius) or a specific value */
+  margin-top: 0.5em; /* Optional: space between heading and list box */
+}
+
+/* Ensure list items inside this specific UL have appropriate color if needed */
+/* This might not be necessary if prose-invert handles it for dark mode */
+.prose h2 + ul li,
+.prose-lg h2 + ul li {
+  /* color: hsl(var(--foreground)); */ /* Example if text color needs adjustment */
+}
+
+/* Dark mode considerations for the conclusions box */
+.dark .prose h2 + ul,
+.dark .prose-lg h2 + ul {
+  background-color: hsl(var(--secondary)); /* Using a dark theme secondary/accent color */
+  /* color: hsl(var(--foreground)); */ /* Ensure text is readable */
 }

--- a/news-blink-frontend/tailwind.config.ts
+++ b/news-blink-frontend/tailwind.config.ts
@@ -66,7 +66,15 @@ export default {
 					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
 					border: 'hsl(var(--sidebar-border))',
 					ring: 'hsl(var(--sidebar-ring))'
-				}
+				},
+        customBlue: {
+          DEFAULT: 'hsl(217, 91%, 60%)',
+          foreground: 'hsl(217, 91%, 98%)'
+        },
+        customLightBlue: {
+          DEFAULT: 'hsl(215, 100%, 95%)',
+          foreground: 'hsl(215, 30%, 25%)'
+        }
 			},
 			borderRadius: {
 				lg: 'var(--radius)',
@@ -94,7 +102,44 @@ export default {
 			animation: {
 				'accordion-down': 'accordion-down 0.2s ease-out',
 				'accordion-up': 'accordion-up 0.2s ease-out'
-			}
+			},
+      typography: (theme) => ({
+        DEFAULT: {
+          css: {
+            // Blockquotes (Cita Destacada)
+            'blockquote': {
+              'font-style': 'italic',
+              'border-left-width': '0.25rem', // Ensure border width is set
+              'border-left-color': theme('colors.customBlue.DEFAULT'),
+              'background-color': theme('colors.customLightBlue.DEFAULT'),
+              'color': theme('colors.customLightBlue.foreground'),
+              'padding-top': '0.5em',
+              'padding-bottom': '0.5em',
+              'padding-left': '1em',
+              'padding-right': '1em',
+            },
+            'blockquote p:first-of-type::before': { content: 'none' },
+            'blockquote p:last-of-type::after': { content: 'none' },
+
+            // For "Conclusiones Clave" List bullets
+            'ul > li::before': {
+              'background-color': theme('colors.customBlue.DEFAULT'),
+            },
+          },
+        },
+        dark: {
+          css: {
+            'blockquote': {
+              'border-left-color': theme('colors.customBlue.DEFAULT'),
+              'background-color': 'hsl(var(--secondary))',
+              'color': 'hsl(var(--foreground))',
+            },
+            'ul > li::before': {
+              'background-color': theme('colors.customBlue.DEFAULT'),
+            },
+          }
+        }
+      }),
 		}
 	},
 	plugins: [require("tailwindcss-animate"), require('@tailwindcss/typography')],


### PR DESCRIPTION
I've updated the Tailwind CSS configuration and custom CSS to style Markdown elements for a more pleasant visual format, as per your design requirements.

Changes:
- `news-blink-frontend/tailwind.config.ts`:
    - Added custom blue color shades.
    - Extended typography plugin to style blockquotes (italic, blue left border, light blue background) and list item bullets (blue).
- `news-blink-frontend/src/index.css`:
    - Added custom CSS to style the unordered list following an h2 (intended for 'Conclusiones Clave') with a light blue rounded background box.
    - Included dark mode considerations for these custom styles.

This aims to make quotes and conclusions visually distinct and aligned with the desired design.