### PR TITLE
Style: Refine quote and conclusions list styling

### DIFF
--- a/news-blink-frontend/src/index.css
+++ b/news-blink-frontend/src/index.css
@@ -142,10 +142,11 @@
 /* Custom styles for Conclusions Key block */
 .prose h2 + ul,
 .prose-lg h2 + ul { /* Targeting ul immediately following an h2 within prose scope */
-  background-color: hsl(215, 100%, 95%); /* customLightBlue.DEFAULT */
-  padding: 1rem; /* Adjust padding as needed */
-  border-radius: 0.5rem; /* var(--radius) or a specific value */
-  margin-top: 0.5em; /* Optional: space between heading and list box */
+  background-color: hsl(217, 90%, 92%);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-top: 0.5em;
+  border: 1px solid hsl(217, 80%, 75%);
 }
 
 /* Ensure list items inside this specific UL have appropriate color if needed */
@@ -158,6 +159,7 @@
 /* Dark mode considerations for the conclusions box */
 .dark .prose h2 + ul,
 .dark .prose-lg h2 + ul {
-  background-color: hsl(var(--secondary)); /* Using a dark theme secondary/accent color */
-  /* color: hsl(var(--foreground)); */ /* Ensure text is readable */
+  background-color: hsl(217, 30%, 25%);
+  border: 1px solid hsl(217, 70%, 55%);
+  /* color: hsl(var(--foreground)); */ /* Ensure text is readable - usually handled by prose-invert */
 }

--- a/news-blink-frontend/tailwind.config.ts
+++ b/news-blink-frontend/tailwind.config.ts
@@ -110,9 +110,9 @@ export default {
             'blockquote': {
               'font-style': 'italic',
               'border-left-width': '0.25rem', // Ensure border width is set
-              'border-left-color': theme('colors.customBlue.DEFAULT'),
-              'background-color': theme('colors.customLightBlue.DEFAULT'),
-              'color': theme('colors.customLightBlue.foreground'),
+              'border-left-color': theme('colors.blue.600'),
+              'background-color': theme('colors.blue.50'),
+              'color': theme('colors.slate.700'),
               'padding-top': '0.5em',
               'padding-bottom': '0.5em',
               'padding-left': '1em',
@@ -130,10 +130,18 @@ export default {
         dark: {
           css: {
             'blockquote': {
-              'border-left-color': theme('colors.customBlue.DEFAULT'),
-              'background-color': 'hsl(var(--secondary))',
-              'color': 'hsl(var(--foreground))',
+              'font-style': 'italic', // Ensure font-style is present for dark mode too
+              'border-left-width': '0.25rem',
+              'border-left-color': theme('colors.blue.500'),
+              'background-color': theme('colors.slate.800'),
+              'color': theme('colors.slate.300'),
+              'padding-top': '0.5em', // Consistent padding
+              'padding-bottom': '0.5em',
+              'padding-left': '1em',
+              'padding-right': '1em',
             },
+            'blockquote p:first-of-type::before': { content: 'none' }, // Ensure quotes are off in dark
+            'blockquote p:last-of-type::after': { content: 'none' },   // Ensure quotes are off in dark
             'ul > li::before': {
               'background-color': theme('colors.customBlue.DEFAULT'),
             },


### PR DESCRIPTION
Further refined frontend styles based on your feedback:

- `news-blink-frontend/tailwind.config.ts`:
    - Adjusted blockquote (quote) colors in typography settings for more prominent blue tones in border and a less faint background, for both light and dark modes.
- `news-blink-frontend/src/index.css`:
    - Updated custom CSS for the conclusions list (ul after h2 in prose) to have a more distinct blue rounded box effect by adjusting background colors and adding borders for both light and dark modes.