### PR TITLE
feat: Manually render quotes & conclusions, revert tailwind config

### DIFF
--- a/news-blink-frontend/src/components/ArticleContent.tsx
+++ b/news-blink-frontend/src/components/ArticleContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import ReactMarkdown from 'react-markdown';
-import { Card, CardContent, CardHeader } from '@/components/ui/card'; // Assuming CardHeader and CardContent are typical for Shadcn Card
+// Removed Card, CardContent, CardHeader imports
 
 interface ArticleContentProps {
-  articleContent?: string;
+  articleContent?: string; // This will be the full Markdown string from AI
 }
 
 interface ContentSegment {
@@ -12,39 +12,28 @@ interface ContentSegment {
   content: string;
 }
 
-// Helper function to parse the article content
 function parseArticleContent(text: string): ContentSegment[] {
   const segments: ContentSegment[] = [];
-  // Regex to find custom tags and the text between them
-  // It looks for <custom_quote>...</custom_quote> or <custom_conclusions>...</custom_conclusions>
-  // The (?:.|\n) allows matching across newlines. *? makes it non-greedy.
-  const regex = /(<custom_quote>(?:.|\n)*?<\/custom_quote>|<custom_conclusions>(?:.|\n)*?<\/custom_conclusions>)/gs;
-
+  const regex = /(<custom_quote>(?:.|
+)*?<\/custom_quote>|<custom_conclusions>(?:.|
+)*?<\/custom_conclusions>)/gs;
   let lastIndex = 0;
   let match;
-
   while ((match = regex.exec(text)) !== null) {
-    // Add content before the current match as a 'main' segment
     if (match.index > lastIndex) {
-      segments.push({ type: 'main', content: text.substring(lastIndex, match.index) });
+      segments.push({ type: 'main', content: text.substring(lastIndex, match.index).trim() });
     }
-
-    // Determine the type of the matched segment and add it
     const matchedText = match[0];
     if (matchedText.startsWith('<custom_quote>')) {
-      segments.push({ type: 'quote', content: matchedText.replace(/<\/?custom_quote>/g, '') });
+      segments.push({ type: 'quote', content: matchedText.replace(/<\/?custom_quote>/g, '').trim() });
     } else if (matchedText.startsWith('<custom_conclusions>')) {
-      segments.push({ type: 'conclusions', content: matchedText.replace(/<\/?custom_conclusions>/g, '') });
+      segments.push({ type: 'conclusions', content: matchedText.replace(/<\/?custom_conclusions>/g, '').trim() });
     }
-
     lastIndex = regex.lastIndex;
   }
-
-  // Add any remaining content after the last match as a 'main' segment
   if (lastIndex < text.length) {
-    segments.push({ type: 'main', content: text.substring(lastIndex) });
+    segments.push({ type: 'main', content: text.substring(lastIndex).trim() });
   }
-
   return segments.filter(segment => segment.content.trim() !== '');
 }
 
@@ -61,43 +50,99 @@ export function ArticleContent({ articleContent }: ArticleContentProps) {
 
   const segments = parseArticleContent(articleContent);
 
-  // Base prose classes for main content
-  const proseClasses = `prose prose-lg max-w-none ${isDarkMode ? 'dark:prose-invert' : ''}`;
-
   return (
-    <div>
+    <div className="space-y-6"> {/* Added space-y-6 like user's "good" example container */}
       {segments.map((segment, index) => {
         if (segment.type === 'quote') {
+          // Parse quote and attribution from segment.content
+          // AI is expected to provide: "> Quote text.
+// - Attribution"
+          let quoteText = segment.content;
+          let attribution = '';
+          const attributionMarker = "\n- "; // Newline then hyphen and space
+          const parts = segment.content.split(attributionMarker);
+          if (parts.length > 1) {
+            quoteText = parts[0].replace(/^>\s*/, '').trim(); // Remove leading '>' and trim
+            attribution = parts.slice(1).join(attributionMarker).trim();
+          } else {
+            quoteText = quoteText.replace(/^>\s*/, '').trim(); // Remove leading '>' if no attribution
+          }
+          // Remove potential surrounding quotes from quoteText if AI adds them
+          quoteText = quoteText.replace(/^["“](.*)["”]$/, '$1');
+
+
           return (
-            <div
-              key={`segment-${index}`}
-              className="my-6 p-4 border-l-4 border-blue-500 bg-customQuoteBg text-customQuoteText italic"
-            >
-              <div className={proseClasses}> {/* Apply prose to content WITHIN the quote box */}
-                <ReactMarkdown>{segment.content}</ReactMarkdown>
-              </div>
+            <div key={`segment-${index}`} className={`p-6 rounded-xl ${isDarkMode ? 'bg-blue-500/10 border-blue-500/20' : 'bg-blue-50 border-blue-200'} border-l-4 ${isDarkMode ? 'border-blue-500' : 'border-blue-600'} my-8`}>
+              <blockquote className={`text-xl italic ${isDarkMode ? 'text-blue-300' : 'text-blue-800'}`}>
+                "{quoteText}"
+              </blockquote>
+              {attribution && (
+                <cite className={`block mt-4 text-sm ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>
+                  - {attribution}
+                </cite>
+              )}
             </div>
           );
         } else if (segment.type === 'conclusions') {
+          // Parse heading and list items from segment.content
+          // AI is expected to provide: "## Conclusiones Clave
+// * Item 1
+// * Item 2"
+          const lines = segment.content.split('\n').filter(line => line.trim() !== '');
+          let heading = 'Conclusiones Clave'; // Default heading
+          const listItems: string[] = [];
+
+          if (lines.length > 0 && lines[0].startsWith('## ')) {
+            heading = lines[0].substring(3).trim(); // Remove "## "
+            lines.slice(1).forEach(line => {
+              if (line.startsWith('* ') || line.startsWith('- ')) {
+                listItems.push(line.substring(2).trim()); // Remove "* " or "- "
+              }
+            });
+          } else { // Fallback if no "## " heading
+             lines.forEach(line => {
+              if (line.startsWith('* ') || line.startsWith('- ')) {
+                listItems.push(line.substring(2).trim());
+              } else if (line.trim()) { // Treat non-empty, non-list lines as part of a single conclusion if no heading
+                listItems.push(line.trim());
+              }
+            });
+          }
+
+          // Take up to 3-5 points as per original AI prompt, user example shows 3
+          const displayListItems = listItems.slice(0, 5);
+
+
+          if (displayListItems.length === 0) return null; // Don't render if no list items found
+
           return (
-            <Card
-              key={`segment-${index}`}
-              className="my-6 bg-customConclusionsBg"
-            >
-              {/* CardHeader and CardContent are optional, but good for structure if AI includes ## Title */}
-              {/* The content from AI is expected to include '## Conclusiones Clave' and list items */}
-              <CardContent className={`pt-6 ${proseClasses}`}> {/* Apply prose. pt-6 for padding if no CardHeader */}
-                <ReactMarkdown>{segment.content}</ReactMarkdown>
-              </CardContent>
-            </Card>
+            <div key={`segment-${index}`} className={`p-6 rounded-xl ${isDarkMode ? 'bg-gray-800/30' : 'bg-gray-50'} mt-8`}>
+              <h3 className={`text-xl font-bold mb-4 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+                {heading}
+              </h3>
+              <ul className={`space-y-3 ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                {displayListItems.map((item, itemIndex) => (
+                  <li key={itemIndex} className="flex items-start space-x-3">
+                    <div className={`w-2 h-2 rounded-full ${isDarkMode ? 'bg-blue-500' : 'bg-blue-600'} mt-2 flex-shrink-0`} />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           );
-        } else { // 'main' content
-          // Only wrap with prose div if there's actual content to avoid empty divs
+        } else { // 'main' content (Markdown)
           if (segment.content.trim() === "") return null;
           return (
-            <div key={`segment-${index}`} className={proseClasses}>
-              <ReactMarkdown>{segment.content}</ReactMarkdown>
-            </div>
+            <ReactMarkdown
+              key={`segment-${index}`}
+              components={{
+                p: ({node, ...props}) => <p className={`text-lg leading-relaxed ${isDarkMode ? 'text-gray-300' : 'text-gray-700'} mb-4`} {...props} />,
+                // Add styling for other elements like h1, h2, ul, ol, a, etc. if needed
+                // For now, only styling paragraphs.
+              }}
+            >
+              {segment.content}
+            </ReactMarkdown>
           );
         }
       })}

--- a/news-blink-frontend/tailwind.config.ts
+++ b/news-blink-frontend/tailwind.config.ts
@@ -65,11 +65,7 @@ export default {
 					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
 					border: 'hsl(var(--sidebar-border))',
 					ring: 'hsl(var(--sidebar-ring))'
-				},
-        customQuoteBg: '#060D19',
-        customQuoteText: '#89B9EE',
-        customConclusionsBg: '#090C11',
-        customConclusionsBullet: '#3B82F6'
+				}
 			},
 			borderRadius: {
 				lg: 'var(--radius)',
@@ -97,26 +93,8 @@ export default {
 			animation: {
 				'accordion-down': 'accordion-down 0.2s ease-out',
 				'accordion-up': 'accordion-up 0.2s ease-out'
-			},
-      typography: (theme) => ({
-        DEFAULT: {
-          css: {
-            // For "Conclusiones Clave" List bullets
-            'ul > li::before': {
-              'background-color': theme('colors.customConclusionsBullet'),
-            },
-          },
-        },
-        dark: {
-          css: {
-            // For "Conclusiones Clave" List bullets
-            'ul > li::before': {
-              'background-color': theme('colors.customConclusionsBullet'),
-            },
-          }
-        }
-      }),
+			}
 		}
 	},
-	plugins: [require("tailwindcss-animate"), require('@tailwindcss/typography')],
+	plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
I refactored `ArticleContent.tsx` to manually render quote and conclusions sections, applying styles directly based on a reference example you provided that achieved the desired visual appearance. This approach replaces the previous method of using ReactMarkdown with prose styling for these specific custom sections.

Key changes in `ArticleContent.tsx`:
- Parses content from `<custom_quote>` and `<custom_conclusions>` tags.
- Quote sections are manually built using JSX (`div`, `blockquote`, `cite`) and styled with Tailwind utility classes (including dark mode variants) from the reference. ReactMarkdown is no longer used for this section.
- Conclusions sections are manually built ( `div`, `h3`, `ul`, `li`) and styled with Tailwind utility classes from the reference. This includes custom bullet styling. ReactMarkdown is no longer used here.
- Main article content (outside custom tags) is still rendered with ReactMarkdown, but now with basic paragraph styling applied via the `components` prop, as the `@tailwindcss/typography` plugin is removed.

Changes in `news-blink-frontend/tailwind.config.ts`:
- Removed the `@tailwindcss/typography` plugin.
- Removed custom color definitions (e.g., `customQuoteBg`) previously added.
- Removed the `theme.extend.typography` section. This simplifies the Tailwind setup and aligns it with the environment where the reference styles were successful, preventing conflicts.

The AI prompt for `format_main_content` is expected to be compatible with the new parsing logic in `ArticleContent.tsx`.