### PR TITLE
fix(frontend): Correct regex in ArticleContent.tsx

### DIFF
--- a/news-blink-frontend/src/components/ArticleContent.tsx
+++ b/news-blink-frontend/src/components/ArticleContent.tsx
@@ -14,9 +14,9 @@ interface ContentSegment {
 
 function parseArticleContent(text: string): ContentSegment[] {
   const segments: ContentSegment[] = [];
-  const regex = /(<custom_quote>(?:.|
-)*?<\/custom_quote>|<custom_conclusions>(?:.|
-)*?<\/custom_conclusions>)/gs;
+  // Corrected Regex: Use .*? with the s flag (dotall) to match any character including newlines.
+  const regex = /(<custom_quote>.*?<\/custom_quote>|<custom_conclusions>.*?<\/custom_conclusions>)/gs;
+
   let lastIndex = 0;
   let match;
   while ((match = regex.exec(text)) !== null) {


### PR DESCRIPTION
Corrected the regular expression in the `parseArticleContent` function within `news-blink-frontend/src/components/ArticleContent.tsx`.

The previous regex literal contained unescaped newline characters, causing an "Unterminated regexp literal" build error.

The regex has been simplified to use `.*?` with the `s` (dotall) flag (already present as `gs`) to correctly match any character, including newlines, within the custom tags.

This resolves the build error and ensures the custom tag parsing logic functions as intended.