### PR TITLE
Fix: Ensure article content is polished to remove duplicate titles

### DIFF
--- a/models/blink_generator.py
+++ b/models/blink_generator.py
@@ -823,6 +823,7 @@ Artículo Estructurado en Formato Markdown:'''
 
         logger.info(f"Formateando a Markdown el texto base para Blink: {title}")
         markdown_content = self.format_content_with_ai(base_content, title)
+        markdown_content = self._polish_markdown_output(markdown_content, title) # Polish the AI-generated markdown
 
         # Crear el objeto BLINK
         blink = {


### PR DESCRIPTION
This commit addresses an oversight in a previous fix (for duplicate titles and conclusion heading redundancies). The `_polish_markdown_output` method, which contains the logic to strip duplicate titles from the article body, was defined in `models/blink_generator.py` but not being called on the final markdown content within the `generate_blink_from_news_group` method.

This change ensures that `_polish_markdown_output` is now correctly invoked after content generation and formatting. This will allow the title-stripping regex (including the rule for `**Title**\n\nBody...` patterns) and other content polishing rules to be applied as intended.

This should resolve the issue of duplicate titles persisting in newly generated articles.