### PR TITLE
Fix: Correct category dropdown styling and padding

### DIFF
--- a/news-blink-frontend/src/components/IntegratedNavigationBar.tsx
+++ b/news-blink-frontend/src/components/IntegratedNavigationBar.tsx
@@ -126,7 +126,7 @@ export const IntegratedNavigationBar = ({
                 <SelectItem 
                   key={category.value} 
                   value={category.value}
-                  className={`text-base py-3 px-4 rounded-lg margin-1 transition-all duration-200 ${isDarkMode 
+                  className={`text-base py-3 pl-8 pr-4 rounded-lg transition-all duration-200 ${isDarkMode
                     ? 'text-white hover:bg-gray-700 focus:bg-gray-700 data-[highlighted]:bg-gray-700' 
                     : 'text-gray-800 hover:bg-gray-100 focus:bg-gray-100 data-[highlighted]:bg-gray-100'}`}
                 >


### PR DESCRIPTION
This commit addresses two styling issues in the category dropdown:

1. Removed an invalid Tailwind CSS class `margin-1` from the `SelectItem` component in `IntegratedNavigationBar.tsx`.
2. Adjusted the padding of `SelectItem` in `IntegratedNavigationBar.tsx` from `px-4` to `pl-8 pr-4`. This ensures enough space for the checkmark indicator, preventing it from overlapping with the item text, and aligns it with the base component's styling.

These changes should improve the visual consistency and correctness of the category filter dropdown.