### PR TITLE
Fix: Correct Tabs component to use Radix UI primitives

### DIFF
--- a/news-blink-frontend/src/components/ui/tabs.jsx
+++ b/news-blink-frontend/src/components/ui/tabs.jsx
@@ -1,45 +1,52 @@
 import React from 'react';
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { cn } from '@/lib/utils';
 
 const Tabs = React.forwardRef(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('w-full', className)} {...props} />
+  <TabsPrimitive.Root
+    ref={ref}
+    className={cn(className)} // w-full was removed as Root doesn't dictate width itself, let consumer do it.
+    {...props} // Props like value, onValueChange, defaultValue, orientation, activationMode will be passed here
+  />
 ));
-Tabs.displayName = 'Tabs';
+Tabs.displayName = TabsPrimitive.Root.displayName;
 
 const TabsList = React.forwardRef(({ className, ...props }, ref) => (
-  <div
+  <TabsPrimitive.List
     ref={ref}
     className={cn(
       'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
       className
     )}
-    {...props}
+    {...props} // Props like loop will be passed here
   />
 ));
-TabsList.displayName = 'TabsList';
+TabsList.displayName = TabsPrimitive.List.displayName;
 
-const TabsTrigger = React.forwardRef(({ className, ...props }, ref) => (
-  <button
+const TabsTrigger = React.forwardRef(({ className, value, ...props }, ref) => (
+  <TabsPrimitive.Trigger
     ref={ref}
+    value={value} // Ensure value prop is explicitly passed
     className={cn(
       'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className
     )}
-    {...props}
+    {...props} // Props like disabled will be passed here
   />
 ));
-TabsTrigger.displayName = 'TabsTrigger';
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
-const TabsContent = React.forwardRef(({ className, ...props }, ref) => (
-  <div
+const TabsContent = React.forwardRef(({ className, value, ...props }, ref) => (
+  <TabsPrimitive.Content
     ref={ref}
+    value={value} // Ensure value prop is explicitly passed
     className={cn(
       'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       className
     )}
-    {...props}
+    {...props} // Props like forceMount will be passed here
   />
 ));
-TabsContent.displayName = 'TabsContent';
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };


### PR DESCRIPTION
I refactored `news-blink-frontend/src/components/ui/tabs.jsx` to properly implement Radix UI Tabs. The previous implementation used divs and buttons, causing an `onValueChange` prop warning and incorrect behavior.

This change ensures:
- `Tabs`, `TabsList`, `TabsTrigger`, and `TabsContent` now wrap the corresponding `TabsPrimitive` components from `@radix-ui/react-tabs`.
- Props like `onValueChange` and `value` are correctly handled by the Radix primitives.
- Resolves the console warning: "Unknown event handler property `onValueChange`. It will be ignored."

This should improve the stability and correctness of the Tabs functionality throughout the application.