### PR TITLE
Fix: Refactor select.jsx to use Radix UI primitives

### DIFF
--- a/news-blink-frontend/src/components/ui/select.jsx
+++ b/news-blink-frontend/src/components/ui/select.jsx
@@ -1,49 +1,147 @@
-import React from 'react';
-import { cn } from '@/lib/utils';
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-const Select = ({ children, value, onValueChange, ...props }) => {
-  return (
-    <div className="relative" {...props}>
-      {React.Children.map(children, child => 
-        React.cloneElement(child, { value, onValueChange })
-      )}
-    </div>
-  );
-};
+const Select = SelectPrimitive.Root;
 
-const SelectTrigger = React.forwardRef(({ className, children, value, onValueChange, ...props }, ref) => (
-  <button
+const SelectGroup = SelectPrimitive.Group;
+
+// SelectValue is used directly from SelectPrimitive.Value
+// It doesn't have specific styling in the original select.jsx that needs to be preserved here beyond what Radix provides.
+// The placeholder styling is often handled on the Trigger or by Radix itself via data-placeholder.
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+      // Classes from original select.jsx SelectTrigger
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      // Added from select.tsx for proper text handling if SelectValue is a direct child with text
+      "[&>span]:line-clamp-1",
       className
     )}
     {...props}
   >
     {children}
-  </button>
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
 ));
-SelectTrigger.displayName = 'SelectTrigger';
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
-const SelectValue = ({ placeholder }) => (
-  <span className="text-muted-foreground">{placeholder}</span>
-);
-
-const SelectContent = ({ children, value, onValueChange }) => (
-  <div className="absolute top-full left-0 z-50 w-full mt-1 bg-background border border-input rounded-md shadow-lg">
-    {React.Children.map(children, child => 
-      React.cloneElement(child, { value, onValueChange })
-    )}
-  </div>
-);
-
-const SelectItem = ({ value: itemValue, children, value, onValueChange }) => (
-  <button
-    className="w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-    onClick={() => onValueChange(itemValue)}
+const SelectScrollUpButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
   >
-    {children}
-  </button>
-);
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
-export { Select, SelectTrigger, SelectValue, SelectContent, SelectItem };
+const SelectScrollDownButton = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        // Base classes from select.tsx for Radix Content
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+        // Animation classes from select.tsx
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        // Original select.jsx SelectContent had shadow-lg, rounded-md. bg-background and border-input are replaced by bg-popover and border. z-50 is kept.
+        // width, mt-1 are handled by popper.
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1", // Default padding for viewport items
+          // Classes from select.tsx for popper mode viewport sizing
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    // Classes from select.tsx
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      // Base classes from select.tsx for Radix Item structure and states
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      // Original select.jsx SelectItem had: "w-full px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+      // We adapt: text-sm is there. hover:bg-accent is covered by focus:bg-accent.
+      // py-1.5 pl-8 pr-2 provides better structure for checkmark than px-3 py-2.
+      // text-left is default for block elements.
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    // Classes from select.tsx
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};


### PR DESCRIPTION
I replaced the custom HTML implementation of the Select component in `news-blink-frontend/src/components/ui/select.jsx` with one based on Radix UI Select primitives (`@radix-ui/react-select`).

This change addresses a critical bug where the category dropdown (which was using `select.jsx`) was stuck open and non-interactive. The previous custom implementation lacked proper state management for opening/closing, event handling (click-outside, Esc), and accessibility features.

The new `select.jsx` now mirrors the structure and functionality of `select.tsx`, ensuring it correctly:
- Manages open/close state.
- Handles item selection.
- Provides keyboard navigation and accessibility.
- Integrates properly with the Radix UI ecosystem used elsewhere in the project.

This should resolve the issues with the category selection dropdown in `IntegratedNavigationBar.tsx`.