### PR TITLE
Fix: Ensure case-insensitive category filtering

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -21,7 +21,7 @@ export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencia
 
   const categoryFilteredNews = useMemo(() => {
     if (selectedCategory === 'all') return searchFilteredNews;
-    return searchFilteredNews.filter(item => item.category === selectedCategory);
+    return searchFilteredNews.filter(item => item.category?.toUpperCase() === selectedCategory);
   }, [searchFilteredNews, selectedCategory]);
 
   const tabFilteredNews = useMemo(() => {


### PR DESCRIPTION
I modified the `useNewsFilter.ts` hook to make the comparison between `item.category` and `selectedCategory` case-insensitive. This is achieved by converting `item.category` to uppercase before comparing it with `selectedCategory`, which is assumed to be stored in uppercase (e.g., 'TECNOLOGÍA'). Optional chaining (`?.`) was also added for robustness against items potentially missing a category.

This change addresses the bug where selecting a category (e.g., "Tecnología") would not display any blinks, even if they existed, due to case mismatches in the category strings.