### PR TITLE
Feat: Reorder navigation tabs

### DIFF
--- a/news-blink-frontend/src/components/IntegratedNavigationBar.tsx
+++ b/news-blink-frontend/src/components/IntegratedNavigationBar.tsx
@@ -49,6 +49,17 @@ export const IntegratedNavigationBar = ({
               : 'bg-white'}`}
           >
             
+            <TabsTrigger
+              value="ultimas"
+              className={`flex items-center justify-center space-x-3 rounded-xl h-12 transition-all duration-300 ${isDarkMode
+                ? 'data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-600/25 text-gray-400 hover:text-gray-200 hover:bg-gray-600'
+                : 'data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-600/25 text-gray-600 hover:text-gray-800 hover:bg-gray-200'} font-bold`}
+            >
+              <Clock className="w-5 h-5" />
+              <span className="hidden sm:inline">ÚLTIMAS</span>
+              <span className="sm:hidden">LAST</span>
+            </TabsTrigger>
+
             <TabsTrigger 
               value="tendencias" 
               className={`flex items-center justify-center space-x-3 rounded-xl h-12 transition-all duration-300 ${isDarkMode 
@@ -69,17 +80,6 @@ export const IntegratedNavigationBar = ({
               <MessageCircle className="w-5 h-5" />
               <span className="hidden sm:inline">RUMORES</span>
               <span className="sm:hidden">RUMOR</span>
-            </TabsTrigger>
-            
-            <TabsTrigger 
-              value="ultimas" 
-              className={`flex items-center justify-center space-x-3 rounded-xl h-12 transition-all duration-300 ${isDarkMode 
-                ? 'data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-600/25 text-gray-400 hover:text-gray-200 hover:bg-gray-600' 
-                : 'data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=active]:shadow-lg data-[state=active]:shadow-blue-600/25 text-gray-600 hover:text-gray-800 hover:bg-gray-200'} font-bold`}
-            >
-              <Clock className="w-5 h-5" />
-              <span className="hidden sm:inline">ÚLTIMAS</span>
-              <span className="sm:hidden">LAST</span>
             </TabsTrigger>
           </TabsList>
         </Tabs>


### PR DESCRIPTION
Reordered the tabs in `IntegratedNavigationBar.tsx` to be ULTIMAS, TENDENCIAS, RUMORES, with ULTIMAS as the default active tab.

This change aligns the visual order of tabs with the desired user experience and the existing logic for the initial active tab.

Output: