### PR TITLE
Fix: Prevent navigation on like/dislike, confirm vote persistence

### DIFF
--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -24,7 +24,8 @@ export const RealPowerBarVoteSystem = ({
   const total = likes + dislikes;
   const likePercentage = total > 0 ? (likes / total) * 100 : 50;
 
-  const handleVote = async (voteType: 'like' | 'dislike') => {
+  const handleVote = async (voteType: 'like' | 'dislike', event: React.MouseEvent) => {
+    event.stopPropagation();
     if (userVote === voteType || isVoting) return;
 
     setIsVoting(true);
@@ -85,7 +86,7 @@ export const RealPowerBarVoteSystem = ({
       {/* Vote Buttons */}
       <div className="flex items-center justify-between gap-6">
         <button
-          onClick={() => handleVote('like')}
+          onClick={(e) => handleVote('like', e)}
           disabled={isVoting}
           className={`flex items-center justify-center space-x-4 px-6 py-3 rounded-xl font-semibold transition-all duration-300 flex-1 transform hover:scale-[1.02] active:scale-[0.98] ${
             userVote === 'like' 
@@ -100,7 +101,7 @@ export const RealPowerBarVoteSystem = ({
         </button>
         
         <button
-          onClick={() => handleVote('dislike')}
+          onClick={(e) => handleVote('dislike', e)}
           disabled={isVoting}
           className={`flex items-center justify-center space-x-4 px-6 py-3 rounded-xl font-semibold transition-all duration-300 flex-1 transform hover:scale-[1.02] active:scale-[0.98] ${
             userVote === 'dislike' 


### PR DESCRIPTION
This commit addresses several issues related to the like/dislike functionality:

1.  **Navigation on Vote:** I modified `RealPowerBarVoteSystem.tsx` to use `event.stopPropagation()` in the vote handlers. This prevents the click event from bubbling up to parent components (specifically `FuturisticNewsCard`), thus stopping unintended navigation to the article details page when you click a like or dislike button. You can now vote on non-featured blinks without being navigated away.

2.  **Vote Persistence:** I confirmed through code review that the backend (`models/news.py`) correctly saves vote counts to the JSON files representing the blinks. The frontend (`RealPowerBarVoteSystem.tsx`) makes API calls to the `/api/vote` endpoint, and the UI optimistically updates, with persisted data loaded on page refresh. The issue of votes not being saved was likely a perceptual one due to the immediate navigation.

3.  **Blink Ordering:** I verified that the backend (`routes/api.py`) already includes logic to sort blinks by a net vote score (likes - dislikes) and then by the number of sources when the 'tendencia' (trending) tab is active. This ensures that more popular articles are displayed prominently.

The primary change was in `news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx` to handle event propagation. Other aspects were verified through code analysis.