### PR TITLE
Fix: Correct voting component in FuturisticNewsCard

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -1,6 +1,6 @@
 
 import { Badge } from '@/components/ui/badge';
-import { PowerBarVoteSystem } from './PowerBarVoteSystem';
+import { RealPowerBarVoteSystem } from './RealPowerBarVoteSystem';
 import { useState, useEffect, useCallback, memo } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 
@@ -158,7 +158,7 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
           
           {/* Vote system at bottom */}
           <div className="flex-shrink-0">
-            <PowerBarVoteSystem
+            <RealPowerBarVoteSystem
               articleId={news.id}
               initialLikes={news.votes?.likes || 0}
               initialDislikes={news.votes?.dislikes || 0}


### PR DESCRIPTION
This commit resolves issues related to liking/disliking blinks on your main news feed:

1.  **Navigation on Vote Stopped:** `FuturisticNewsCard.tsx` was previously using `PowerBarVoteSystem.tsx`, which lacked event propagation control and used mock API calls. This commit changes `FuturisticNewsCard.tsx` to use `RealPowerBarVoteSystem.tsx`. The `RealPowerBarVoteSystem` component correctly calls `event.stopPropagation()` on vote actions, preventing the click from bubbling up to the card's navigation handler. This stops the unintended navigation when you like or dislike a blink.

2.  **Vote Persistence and Accuracy:** By switching to `RealPowerBarVoteSystem.tsx`, votes made from `FuturisticNewsCard` instances are now sent to the actual backend API (`/api/vote`). This ensures that votes are correctly persisted in the backend data files.

3.  **Correct Featured Blink Display:** With votes being accurately persisted, the backend's sorting logic for the 'tendencia' (trending) tab now operates on correct data. Consequently, the most voted blink will be correctly identified and displayed as the featured item on the main page.

The article detail page (`BlinkDetail.tsx` via `KeyPointsSidebar.tsx`) was already using `RealPowerBarVoteSystem.tsx` and functioning correctly in isolation. The primary issue was the incorrect component usage in the news card list, which affected data integrity and your experience. This change harmonizes the voting mechanism across the application.