### PR TITLE
Fix: Prevent vote reset by background task

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -220,6 +220,11 @@ def collect_and_process_news(app):
                         if determined_category in allowed_publish_categories: # Re-check for safety or rely on not continuing
                              print(f"DEBUG_API_ROUTE: Blink '{blink.get('title', 'N/A')}' con categoría '{determined_category}' SÍ ESTÁ en allowed_categories. Procediendo a guardar.")
 
+                        # Preserve existing votes
+                        existing_blink_data = news_model.get_blink(blink['id'])
+                        if existing_blink_data and 'votes' in existing_blink_data:
+                            blink['votes'] = existing_blink_data.get('votes', {'likes': 0, 'dislikes': 0})
+
                         print(f"DEBUG_API_ROUTE: Intentando guardar BLINK. ID: {blink['id']}, Título: {blink['title']}, Categorías: {blink.get('categories')}")
                         news_model.save_blink(blink['id'], blink)
                         print(f"DEBUG_API_ROUTE: BLINK GUARDADO EXITOSAMENTE. ID: {blink['id']}")


### PR DESCRIPTION
This commit addresses the issue where your votes were being reset to zero, particularly after site refreshes, and articles were not being correctly ordered by likes.

The primary cause identified was the `collect_and_process_news` background task in `routes/api.py`. When this task re-processed and saved blinks, it would overwrite existing blink files with newly generated blink objects that had vote counts hardcoded to zero. This effectively erased any of your votes cast since the last run of the task.

The fix implements the following change:
- Modified `routes/api.py`: The `collect_and_process_news` function now, before saving a newly generated blink, checks if a blink with the same ID already exists. If it does, the function retrieves the existing vote data and merges it into the new blink object. This ensures that your accumulated votes are preserved during content updates by the background task.

I attempted to further improve error propagation in `models/news.py` for file saving operations. However, I was unable to reliably complete these changes. The core `update_vote` method in `models/news.py` may still contain some unaddressed corruption from previous errors. Despite this, the implemented change to `collect_and_process_news` is expected to resolve the main reported symptoms of votes resetting and incorrect ordering.