### PR TITLE
Refactor: Update tab behavior and default sorting for blinks

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -29,7 +29,9 @@ export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencia
     // console.log('[useNewsFilter] Inside tabFilteredNews memo. Start. categoryFilteredNews length:', categoryFilteredNews.length, 'activeTab:', activeTab); // Optional inner log
     switch (activeTab) {
       case 'tendencias':
-        filtered = filtered.filter(item => item.isHot || item.aiScore > 85);
+        // No specific client-side filtering or sorting here for 'tendencias'.
+        // It will use the data from categoryFilteredNews, which is already
+        // sorted by likes (primary) and timestamp (secondary) from the backend.
         break;
       case 'rumores':
         filtered = filtered.filter(item => item.category === 'RUMORES' || item.aiScore < 90);

--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -22,7 +22,7 @@ const Index = () => {
     activeTab,
     setActiveTab,
     clearFilters
-  } = useNewsFilter(news, 'ultimas');
+  } = useNewsFilter(news, 'tendencias'); // Changed 'ultimas' to 'tendencias'
 
   const [heroNews, setHeroNews] = useState(null);
 


### PR DESCRIPTION
This commit implements changes based on your feedback to modify the default tab, adjust filtering and sorting logic for the 'Tendencias' tab, and verify the behavior of other existing tabs.

Key changes:

1.  **Default Tab Changed to 'Tendencias':**
    *   In `news-blink-frontend/src/pages/Index.tsx`, the `initialActiveTab`
      for the `useNewsFilter` hook is now set to `'tendencias'` instead
      of `'ultimas'`.

2.  **'Tendencias' Tab Logic Modified (`useNewsFilter.ts`):**
    *   Removed the previous client-side filter for the 'tendencias' tab
      (which was based on `item.isHot` or `item.aiScore`).
    *   The 'Tendencias' tab now displays blinks based on the general
      category/search filters and relies on the backend's default
      sorting order (by likes, then timestamp), which is fetched by
      `useRealNews`.

3.  **Other Tab Behaviors Verified (`useNewsFilter.ts`):**
    *   The 'Ultimas' tab continues to sort by publication date (client-side).
    *   The 'Rumores' tab continues to filter for items related to rumors
      and will display them in the like-sorted order provided by the backend.

These changes ensure that the application defaults to a view sorted by likes ('Tendencias') and that different tabs apply their specific filtering and sorting rules as requested.