### PR TITLE
Fix: Correct import paths and ensure clean Zustand installation

### DIFF
--- a/news-blink-frontend/.dockerignore
+++ b/news-blink-frontend/.dockerignore
@@ -1,2 +1,3 @@
 # Ignorar las dependencias locales para que Docker no intente copiarlas
 node_modules
+pnpm-lock.yaml

--- a/news-blink-frontend/package.json
+++ b/news-blink-frontend/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { voteOnArticle, NewsItem } from '@/utils/api'; // Imported NewsItem
-import { useNewsStore } from '../../store/newsStore'; // Import the Zustand store
+import { useNewsStore } from '../store/newsStore'; // Corrected import path
 
 interface RealPowerBarVoteSystemProps {
   articleId: string;


### PR DESCRIPTION
This commit addresses issues related to resolving the 'zustand' dependency and an incorrect import path for the newsStore.

1.  **Correct Import Path (`RealPowerBarVoteSystem.tsx`):**
    *   Changed the import path for `useNewsStore` from
      `../../store/newsStore` to `../store/newsStore` to correctly
      locate the store module.

2.  **Ensure Clean `zustand` Installation:**
    *   Added `pnpm-lock.yaml` to `news-blink-frontend/.dockerignore`
      to ensure `pnpm install` in Docker generates a fresh lock file
      based on `package.json`.
    *   Verified and explicitly added `"zustand": "^4.5.0"` to the
      `dependencies` in `news-blink-frontend/package.json`.

These changes are intended to resolve build errors related to module resolution for Zustand and the news store. A Docker image rebuild for the frontend using `--no-cache` is recommended after pulling these changes to ensure dependencies are correctly installed.