### PR TITLE
Fix: Resolve ReferenceError for updateSingleNewsItem in useRealNews

### DIFF
--- a/news-blink-frontend/src/hooks/useRealNews.ts
+++ b/news-blink-frontend/src/hooks/useRealNews.ts
@@ -39,7 +39,6 @@ export const useRealNews = () => {
     loading,
     error,
     loadNews,
-    refreshNews,
-    updateSingleNewsItem
+    refreshNews
   };
 };


### PR DESCRIPTION
This commit fixes a `ReferenceError: updateSingleNewsItem is not defined` that occurred in the `useRealNews` hook.

The `updateSingleNewsItem` function was removed from the hook's definition during the refactoring to Zustand, as its functionality was replaced by the `updateBlinkInList` action in the `newsStore`. However, a reference to `updateSingleNewsItem` was inadvertently left in the return object of the `useRealNews` hook.

This commit removes the erroneous reference from the return statement. The `useRealNews` hook now correctly returns only: `{ news, loading, error, loadNews, refreshNews }`, all of which are properly defined and sourced from the Zustand store or are functions interacting with the store.

This fix should resolve the blank page issue and allow the application to load and function as intended with the new Zustand-based state management and real-time update features.