### PR TITLE
Feat: Sort blinks by interest percentage, then likes, then timestamp

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -29,18 +29,28 @@ export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencia
     // console.log('[useNewsFilter] Inside tabFilteredNews memo. Start. categoryFilteredNews length:', categoryFilteredNews.length, 'activeTab:', activeTab); // Optional inner log
     switch (activeTab) {
       case 'tendencias':
-        // Sort by likes (descending), then by timestamp (descending) if likes are equal.
-        // This ensures that if a vote changes, the client-side sorting reflects it immediately
-        // and maintains a consistent order similar to the backend's default.
         filtered.sort((a, b) => {
-          const likesA = a.votes?.likes || 0;
-          const likesB = b.votes?.likes || 0;
+          const votesA = a.votes || { likes: 0, dislikes: 0 };
+          const likesA = votesA.likes || 0;
+          const dislikesA = votesA.dislikes || 0;
+          const totalVotesA = likesA + dislikesA;
+          const scoreA = totalVotesA > 0 ? likesA / totalVotesA : 0.0;
 
-          if (likesB !== likesA) {
-            return likesB - likesA; // Primary sort: likes descending
+          const votesB = b.votes || { likes: 0, dislikes: 0 };
+          const likesB = votesB.likes || 0;
+          const dislikesB = votesB.dislikes || 0;
+          const totalVotesB = likesB + dislikesB;
+          const scoreB = totalVotesB > 0 ? likesB / totalVotesB : 0.0;
+
+          if (scoreB !== scoreA) {
+            return scoreB - scoreA; // Primary: interest score descending
           }
 
-          // Secondary sort: publishedAt (timestamp) descending
+          if (likesB !== likesA) {
+            return likesB - likesA; // Secondary: absolute likes descending
+          }
+
+          // Tertiary: publishedAt (timestamp) descending
           const timestampA = new Date(a.publishedAt || 0).getTime();
           const timestampB = new Date(b.publishedAt || 0).getTime();
           return timestampB - timestampA;

--- a/routes/api.py
+++ b/routes/api.py
@@ -193,12 +193,22 @@ def get_all_blinks_sorted():
     # Handle missing 'votes' or 'likes' by defaulting to 0
     # Handle missing 'timestamp' by defaulting to a very old date (or empty string for type consistency if preferred)
     def sort_key(blink):
-        likes = blink.get('votes', {}).get('likes', 0)
-        # Assuming timestamp is a string like '2023-10-20T12:00:00Z' or similar that can be string-compared
-        # Or if it's a Unix timestamp (number), direct comparison works.
-        # Default to 0 or an "early" string if missing, to ensure they go to the end if primary key is same.
-        timestamp = blink.get('timestamp', 0) # Assuming numeric/comparable or string 'YYYY-MM-DD...'
-        return (likes, timestamp)
+        votes = blink.get('votes', {})
+        likes = votes.get('likes', 0)
+        dislikes = votes.get('dislikes', 0)
+
+        total_votes = likes + dislikes
+        interest_score = 0.0
+        if total_votes > 0:
+            interest_score = likes / total_votes
+
+        timestamp = blink.get('timestamp', 0) # Keep existing timestamp logic
+
+        # Sort by:
+        # 1. Interest score (higher is better)
+        # 2. Absolute likes (higher is better, for tie-breaking interest score)
+        # 3. Timestamp (newer is better, for tie-breaking both)
+        return (interest_score, likes, timestamp)
 
     all_blinks_data.sort(key=sort_key, reverse=True)
 


### PR DESCRIPTION
This commit updates the sorting logic for blinks in both the backend and the frontend's 'Tendencias' tab to prioritize an 'interest percentage' score, addressing your feedback that the previous like-based sorting was not intuitive.

Key changes:

1.  **Backend Sorting (`routes/api.py`):**
    *   Modified the `sort_key` function within `get_all_blinks_sorted`.
    *   Blinks are now sorted by:
        a.  Interest percentage (`likes / (likes + dislikes)`), descending.
            (Calculated as 0.0 if total votes are 0).
        b.  Absolute number of `likes`, descending (tie-breaker).
        c.  `timestamp`, descending (final tie-breaker).

2.  **Frontend Sorting (`useNewsFilter.ts`):**
    *   Updated the client-side sorting logic for the `case 'tendencias'`.
    *   It now mirrors the backend's multi-level sorting: interest
      percentage, then absolute likes, then `publishedAt` timestamp.
      This ensures that real-time re-sorting after votes on the
      'Tendencias' tab is consistent with the initial load order.

This change aligns the blink sorting order with your expectations based on the displayed 'percentage of interest', ensuring that items with higher engagement quality (higher like-to-total-vote ratio) are prioritized, while still considering vote volume and recency as secondary and tertiary factors.