### PR TITLE
Fix: Ensure robust score calculation for interest-based sorting

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -31,14 +31,14 @@ export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencia
       case 'tendencias':
         filtered.sort((a, b) => {
           const votesA = a.votes || { likes: 0, dislikes: 0 };
-          const likesA = votesA.likes || 0;
-          const dislikesA = votesA.dislikes || 0;
+          const likesA = Number(votesA.likes || 0);
+          const dislikesA = Number(votesA.dislikes || 0);
           const totalVotesA = likesA + dislikesA;
           const scoreA = totalVotesA > 0 ? likesA / totalVotesA : 0.0;
 
           const votesB = b.votes || { likes: 0, dislikes: 0 };
-          const likesB = votesB.likes || 0;
-          const dislikesB = votesB.dislikes || 0;
+          const likesB = Number(votesB.likes || 0);
+          const dislikesB = Number(votesB.dislikes || 0);
           const totalVotesB = likesB + dislikesB;
           const scoreB = totalVotesB > 0 ? likesB / totalVotesB : 0.0;
 

--- a/routes/api.py
+++ b/routes/api.py
@@ -194,21 +194,28 @@ def get_all_blinks_sorted():
     # Handle missing 'timestamp' by defaulting to a very old date (or empty string for type consistency if preferred)
     def sort_key(blink):
         votes = blink.get('votes', {})
-        likes = votes.get('likes', 0)
-        dislikes = votes.get('dislikes', 0)
+        # Explicitly cast to int, defaulting to 0 if key is missing or value is not convertible
+        try:
+            likes = int(votes.get('likes', 0))
+        except (ValueError, TypeError):
+            likes = 0
+        try:
+            dislikes = int(votes.get('dislikes', 0))
+        except (ValueError, TypeError):
+            dislikes = 0
 
         total_votes = likes + dislikes
         interest_score = 0.0
         if total_votes > 0:
-            interest_score = likes / total_votes
+            interest_score = float(likes) / total_votes # float() ensures float division
 
-        timestamp = blink.get('timestamp', 0) # Keep existing timestamp logic
+        timestamp_val = blink.get('timestamp', 0) # Renamed to avoid conflict if any
 
         # Sort by:
         # 1. Interest score (higher is better)
         # 2. Absolute likes (higher is better, for tie-breaking interest score)
         # 3. Timestamp (newer is better, for tie-breaking both)
-        return (interest_score, likes, timestamp)
+        return (interest_score, likes, timestamp_val)
 
     all_blinks_data.sort(key=sort_key, reverse=True)
 


### PR DESCRIPTION
This commit makes the calculation of the 'interest percentage' score more robust in both the backend and frontend sorting logic. This is to prevent potential misorderings if 'likes' or 'dislikes' values in the data are not strictly numeric (e.g., stringified numbers).

Key changes:

1.  **Backend (`routes/api.py`):**
    *   In the `sort_key` function within `get_all_blinks_sorted`,
      `likes` and `dislikes` values retrieved from blink data are now
      explicitly converted to integers using `int()`, with a `try-except`
      block to default to 0 if conversion fails. This ensures these
      values are numeric before being used in arithmetic operations for
      calculating `total_votes` and `interest_score`.

2.  **Frontend (`useNewsFilter.ts`):**
    *   In the client-side sorting logic for the 'Tendencias' tab,
      `likes` and `dislikes` values from each news item are now
      explicitly converted to numbers using `Number()` before calculating
      `totalVotes` and `interest_score`.

These changes ensure that the sorting mechanisms are resilient to potential data type inconsistencies in vote counts, leading to more accurate and reliable sorting based on the intended 'interest percentage' metric, followed by absolute likes and timestamp as tie-breakers.