### PR TITLE
Feat: Implement smooth list reordering animations

### DIFF
--- a/news-blink-frontend/package.json
+++ b/news-blink-frontend/package.json
@@ -51,6 +51,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-flip-toolkit": "^7.1.0",
     "react-hook-form": "^7.53.0",
     "react-markdown": "^9.0.1",
     "react-resizable-panels": "^2.1.3",

--- a/news-blink-frontend/src/components/NewsGrid.tsx
+++ b/news-blink-frontend/src/components/NewsGrid.tsx
@@ -1,21 +1,32 @@
 
 import { FuturisticNewsCard } from '@/components/FuturisticNewsCard';
+import { Flipper, Flipped } from 'react-flip-toolkit';
 
 interface NewsGridProps {
-  news: any[];
+  news: any[]; // Assuming items have an 'id' property
   onCardClick: (id: string) => void;
 }
 
 export const NewsGrid = ({ news, onCardClick }: NewsGridProps) => {
+  const flipKey = news.map(item => item.id).join(',');
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <Flipper
+      flipKey={flipKey}
+      className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+      spring="gentle" // Optional: added a spring preset for smoother animation
+    >
       {news.map((item) => (
-        <FuturisticNewsCard
-          key={item.id}
-          news={item}
-          onCardClick={onCardClick}
-        />
+        <Flipped key={item.id} flipId={item.id}>
+          <div>
+            <FuturisticNewsCard
+              // key prop is on the Flipped component now
+              news={item}
+              onCardClick={onCardClick}
+            />
+          </div>
+        </Flipped>
       ))}
-    </div>
+    </Flipper>
   );
 };

--- a/news-blink-frontend/src/components/RumorGrid.tsx
+++ b/news-blink-frontend/src/components/RumorGrid.tsx
@@ -1,21 +1,32 @@
 
 import { RumorCard } from '@/components/RumorCard';
+import { Flipper, Flipped } from 'react-flip-toolkit';
 
 interface RumorGridProps {
-  news: any[];
+  news: any[]; // Assuming items have an 'id' property
   onCardClick: (id: string) => void;
 }
 
 export const RumorGrid = ({ news, onCardClick }: RumorGridProps) => {
+  const flipKey = news.map(item => item.id).join(',');
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <Flipper
+      flipKey={flipKey}
+      className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+      spring="gentle"
+    >
       {news.map((item) => (
-        <RumorCard
-          key={item.id}
-          news={item}
-          onCardClick={onCardClick}
-        />
+        <Flipped key={item.id} flipId={item.id}>
+          <div>
+            <RumorCard
+              // key prop is on the Flipped component now
+              news={item}
+              onCardClick={onCardClick}
+            />
+          </div>
+        </Flipped>
       ))}
-    </div>
+    </Flipper>
   );
 };


### PR DESCRIPTION
This commit introduces smooth list transition animations when blinks are reordered, for example, due to vote changes in the 'Tendencias' tab. This addresses your feedback requesting more organic and elegant UI updates instead of abrupt jumps.

The `react-flip-toolkit` library has been used to achieve this.

Key changes:

1.  **Add Dependency:**
    *   Added `"react-flip-toolkit": "^7.1.0"` to the `dependencies`
      in `news-blink-frontend/package.json`. (Requires `pnpm install`
      in the frontend environment after pulling).

2.  **Integrate into `NewsGrid.tsx`:**
    *   The main grid container is now wrapped with the `<Flipper>`
      component from `react-flip-toolkit`.
    *   A `flipKey` (derived from the ordered list of item IDs) is
      provided to `<Flipper>` to trigger animations on order change.
    *   Each `FuturisticNewsCard` is wrapped with `<Flipped flipId={item.id}>`
      to enable individual item animation.
    *   Added `spring="gentle"` to `<Flipper>` for a pleasant default
      animation.

3.  **Integrate into `RumorGrid.tsx`:**
    *   Applied the same `Flipper` and `Flipped` integration pattern
      to `RumorGrid.tsx` and its `RumorCard` children.

This implementation should provide a smoother experience for you when interacting with lists that dynamically reorder. Animations for items moving to/from a separate hero/featured section are not included in this specific change.