### PR TITLE
Fix: Restore fixed height for blink cards after animation integration

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -50,7 +50,7 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
       onClick={handleCardClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="cursor-pointer h-auto min-h-[600px] flex flex-col"
+      className="cursor-pointer h-[600px] flex flex-col overflow-hidden" // Changed className
     >
       <div className={`relative h-full flex flex-col ${isDarkMode 
         ? 'bg-gray-900' 

--- a/news-blink-frontend/src/components/RumorCard.tsx
+++ b/news-blink-frontend/src/components/RumorCard.tsx
@@ -28,7 +28,7 @@ export const RumorCard = memo(({ news, onCardClick }: RumorCardProps) => {
   return (
     <div 
       onClick={handleCardClick}
-      className="cursor-pointer h-auto"
+      className="cursor-pointer h-[600px] flex flex-col overflow-hidden" // Changed className
     >
       <div className={`relative h-full flex flex-col ${isDarkMode 
         ? 'bg-slate-900/80' 


### PR DESCRIPTION
This commit addresses an issue where blink cards (`FuturisticNewsCard` and `RumorCard`) started rendering with variable heights after the introduction of `react-flip-toolkit` for list animations. The cards are now styled to have a consistent, fixed height.

Key changes:

1.  **`FuturisticNewsCard.tsx`:**
    *   The `className` of the outermost `div` was changed from
      `h-auto min-h-[600px]` to `h-[600px] overflow-hidden`. This enforces
      a fixed height and clips overflowing content.

2.  **`RumorCard.tsx`:**
    *   The `className` of the outermost `div` was changed from
      `h-auto` to `h-[600px] flex flex-col overflow-hidden`. This
      enforces a fixed height, ensures consistent flex container behavior,
      and clips overflowing content, aligning it with `FuturisticNewsCard`.

These changes ensure that all cards displayed in the grids maintain a uniform height, restoring the previous visual consistency while preserving the smooth reordering animations.