### PR TITLE
Fix: Implement stretch-fill height for cards with internal scrolling

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -50,7 +50,7 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
       onClick={handleCardClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="cursor-pointer h-[600px] flex flex-col overflow-hidden" // Changed className
+      className="cursor-pointer h-full flex flex-col" // Changed: Use h-full
     >
       <div className={`relative h-full flex flex-col ${isDarkMode 
         ? 'bg-gray-900' 
@@ -102,8 +102,8 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
           </div>
           
           {/* Optimized bullets section */}
-          <div className="flex-1 flex flex-col justify-center mb-5">
-            <div className="space-y-2 relative">
+          <div className="flex-1 flex flex-col justify-center mb-5 overflow-hidden"> {/* Added overflow-hidden */}
+            <div className="space-y-2 relative overflow-y-auto"> {/* Added overflow-y-auto */}
               {news.points.slice(0, 5).map((point: string, index: number) => {
                 const isActive = isHovered && currentBullet === index;
 

--- a/news-blink-frontend/src/components/NewsGrid.tsx
+++ b/news-blink-frontend/src/components/NewsGrid.tsx
@@ -18,7 +18,7 @@ export const NewsGrid = ({ news, onCardClick }: NewsGridProps) => {
     >
       {news.map((item) => (
         <Flipped key={item.id} flipId={item.id}>
-          <div>
+          <div className="h-full flex flex-col">
             <FuturisticNewsCard
               // key prop is on the Flipped component now
               news={item}

--- a/news-blink-frontend/src/components/RumorCard.tsx
+++ b/news-blink-frontend/src/components/RumorCard.tsx
@@ -28,7 +28,7 @@ export const RumorCard = memo(({ news, onCardClick }: RumorCardProps) => {
   return (
     <div 
       onClick={handleCardClick}
-      className="cursor-pointer h-[600px] flex flex-col overflow-hidden" // Changed className
+      className="cursor-pointer h-full flex flex-col" // Changed
     >
       <div className={`relative h-full flex flex-col ${isDarkMode 
         ? 'bg-slate-900/80' 
@@ -73,7 +73,7 @@ export const RumorCard = memo(({ news, onCardClick }: RumorCardProps) => {
         </div>
         
         {/* Content section */}
-        <div className="p-5 flex-1 flex flex-col space-y-4">
+        <div className="p-5 flex-1 flex flex-col space-y-4 overflow-hidden"> {/* Added overflow-hidden */}
           <div>
             <h3 className={`text-lg font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'} leading-tight mb-2`}>
               {news.title}
@@ -99,7 +99,7 @@ export const RumorCard = memo(({ news, onCardClick }: RumorCardProps) => {
           </div>
           
           {/* Rumor points */}
-          <div className="flex-1 space-y-2">
+          <div className="flex-1 space-y-2 overflow-y-auto"> {/* Added overflow-y-auto */}
             {news.points.slice(0, 3).map((point: string, index: number) => (
               <div key={index} className="flex items-start space-x-2">
                 <div className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 ${isDarkMode 

--- a/news-blink-frontend/src/components/RumorGrid.tsx
+++ b/news-blink-frontend/src/components/RumorGrid.tsx
@@ -18,7 +18,7 @@ export const RumorGrid = ({ news, onCardClick }: RumorGridProps) => {
     >
       {news.map((item) => (
         <Flipped key={item.id} flipId={item.id}>
-          <div>
+          <div className="h-full flex flex-col">
             <RumorCard
               // key prop is on the Flipped component now
               news={item}


### PR DESCRIPTION
This commit addresses issues with card height consistency and content clipping that arose after previous attempts to fix heights following the integration of `react-flip-toolkit`.

The new strategy ensures cards in the same grid row have uniform height by stretching to the height of the tallest card in that row, while allowing internal content areas (like bullet points) to scroll if their content exceeds the allocated space.

Key changes:

1.  **Reverted Restrictive Fixed Heights:**
    *   I removed the `h-[600px] overflow-hidden` styling from
      `FuturisticNewsCard.tsx` and `RumorCard.tsx` that was causing
      content clipping. I restored `h-auto` and `min-h-[600px]` for
      `FuturisticNewsCard` and `h-auto` for `RumorCard` temporarily
      before applying the new strategy.

2.  **Grid Item Wrapper Styling (`NewsGrid.tsx`, `RumorGrid.tsx`):**
    *   The `div` immediately inside each `<Flipped>` component (which
      wraps the card) has been updated to `className="h-full flex flex-col"`.
      This allows this wrapper to stretch to the grid cell's height and
      establishes a flex context.

3.  **Card Component Styling (`FuturisticNewsCard.tsx`, `RumorCard.tsx`):**
    *   The outermost `div` of both card types is now styled with
      `className="h-full flex flex-col"`. This makes the cards fill the
      height of their parent wrapper (the grid item). `h-auto` and
      `min-h-` classes were removed from these outermost divs.
    *   Specific internal sections responsible for displaying lists of
      points have been modified:
        *   Their direct parent container (often a `flex-1` item) has
          `overflow-hidden` added.
        *   The points list container itself has `overflow-y-auto` added
          to enable vertical scrolling if content is too long.

This approach should provide uniform card heights per row, prevent content clipping, and maintain smooth list reordering animations.