### PR TITLE
Fix: Remove internal card scrollbars and restore natural height

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -102,8 +102,8 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
           </div>
           
           {/* Optimized bullets section */}
-          <div className="flex-1 flex flex-col justify-center mb-5 overflow-hidden"> {/* Added overflow-hidden */}
-            <div className="space-y-2 relative overflow-y-auto"> {/* Added overflow-y-auto */}
+          <div className="flex-1 flex flex-col justify-center mb-5"> {/* Removed overflow-hidden */}
+            <div className="space-y-2 relative"> {/* Removed overflow-y-auto */}
               {news.points.slice(0, 5).map((point: string, index: number) => {
                 const isActive = isHovered && currentBullet === index;
 

--- a/news-blink-frontend/src/components/RumorCard.tsx
+++ b/news-blink-frontend/src/components/RumorCard.tsx
@@ -73,7 +73,7 @@ export const RumorCard = memo(({ news, onCardClick }: RumorCardProps) => {
         </div>
         
         {/* Content section */}
-        <div className="p-5 flex-1 flex flex-col space-y-4 overflow-hidden"> {/* Added overflow-hidden */}
+        <div className="p-5 flex-1 flex flex-col space-y-4"> {/* Removed overflow-hidden */}
           <div>
             <h3 className={`text-lg font-bold ${isDarkMode ? 'text-white' : 'text-slate-900'} leading-tight mb-2`}>
               {news.title}
@@ -99,7 +99,7 @@ export const RumorCard = memo(({ news, onCardClick }: RumorCardProps) => {
           </div>
           
           {/* Rumor points */}
-          <div className="flex-1 space-y-2 overflow-y-auto"> {/* Added overflow-y-auto */}
+          <div className="flex-1 space-y-2"> {/* Removed overflow-y-auto */}
             {news.points.slice(0, 3).map((point: string, index: number) => (
               <div key={index} className="flex items-start space-x-2">
                 <div className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 ${isDarkMode 


### PR DESCRIPTION
This commit addresses your feedback regarding unwanted scrollbars appearing within blink cards after previous attempts to manage card heights with animation libraries. The changes restore the original behavior where card content fully displays by allowing the card to expand, and relies on CSS Grid to maintain uniform row heights.

Key changes:

1.  **`FuturisticNewsCard.tsx`:**
    *   I removed `overflow-y-auto` from the bullet points list container.
    *   I removed `overflow-hidden` from the parent of the bullet points
      list container.
    *   The card's internal flex layout will now allow the points section
      to expand vertically, adjusting the card's overall height.

2.  **`RumorCard.tsx`:**
    *   Similarly, I removed `overflow-y-auto` from the rumor points list
      container.
    *   I removed `overflow-hidden` from its parent "Content section" `div`.
    *   This card's points section will also now expand vertically based
      on its content.

3.  **Height Unification Strategy:**
    *   Both card types (`FuturisticNewsCard`, `RumorCard`) and their
      wrappers within the grid components (`NewsGrid`, `RumorGrid`) are
      configured with `h-full` and `flex flex-col`. This allows them to
      stretch to the height of the tallest item in their respective grid
      row, ensuring uniform height per row without enforcing a restrictive
      global fixed height on the cards themselves.

This approach ensures all card content is visible without internal scrollbars, cards adjust their height to their content, and cards within the same row maintain a consistent height due to CSS Grid's `align-items: stretch` behavior. Reordering animations should remain smooth.