### PR TITLE
Fix(frontend): Ensure 0-vote blinks display 0% interest

### DIFF
--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -26,7 +26,7 @@ export const RealPowerBarVoteSystem = ({
   const [isVoting, setIsVoting] = useState(false);
 
   const total = likes + dislikes;
-  const likePercentage = total > 0 ? (likes / total) * 100 : 50;
+  const likePercentage = total > 0 ? (likes / total) * 100 : 0;
 
   const handleVote = async (voteType: 'like' | 'dislike', event: React.MouseEvent) => {
     event.stopPropagation();


### PR DESCRIPTION
I modified `RealPowerBarVoteSystem.tsx` to correctly calculate and display the interest percentage. Previously, if a blink had 0 total votes (0 likes and 0 dislikes), the interest bar would default to showing 50%. This change ensures that in such cases, the `likePercentage` is set to 0, resulting in the UI displaying 0% interest.