### PR TITLE
Fix(frontend): Synchronize hero blink display with Zustand store

### DIFF
--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -24,7 +24,7 @@ const Index = () => {
     clearFilters
   } = useNewsFilter(news, 'tendencias'); // Changed 'ultimas' to 'tendencias'
 
-  const [heroNews, setHeroNews] = useState(null);
+  const heroNews = filteredNews.length > 0 ? filteredNews[0] : null;
 
   // REMOVED:
   // useEffect(() => {
@@ -37,11 +37,7 @@ const Index = () => {
     }
   }, [activeTab, loadNews]); // loadNews is from useRealNews
 
-  useEffect(() => {
-    if (filteredNews.length > 0) {
-      setHeroNews(filteredNews[0]);
-    }
-  }, [filteredNews]);
+  // useEffect for setHeroNews removed
 
   const handleRefresh = () => {
     refreshNews(activeTab);


### PR DESCRIPTION
This commit refactors frontend components to eliminate duplicated state and ensure that displayed blink data, especially for the hero/featured blink, is consistently sourced from the central Zustand store. This addresses UI inconsistencies where vote counts or the hero blink itself would not update correctly without a full page refresh.

Changes:

1.  `news-blink-frontend/src/pages/Index.tsx`:
    - I removed the local `heroNews` state (`useState`).
    - I removed the `useEffect` hook that updated this local state.
    - `heroNews` is now derived directly from the `filteredNews` prop (sourced from Zustand via `useNewsFilter`) on each render. This ensures the hero blink data is always fresh.

2.  `news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx`:
    - I removed local `useState` for `likes` and `dislikes`.
    - The component now receives `likes` and `dislikes` directly as props (renamed from `initialLikes`/`initialDislikes`).
    - It no longer performs optimistic updates on its own local vote state, relying instead on prop changes triggered by updates to the Zustand store (e.g., via `updateBlinkInList` after a vote API call).
    - This makes the component a "controlled" or "dumb" component regarding vote counts, ensuring it reflects the Zustand store's state.

These changes align with using the Zustand store as the single source of truth and should resolve issues of stale data being displayed in the UI, particularly for the hero blink and its vote counts.