### PR TITLE
Debug: Add render log to RealPowerBarVoteSystem

### DIFF
--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -18,6 +18,7 @@ export const RealPowerBarVoteSystem = ({
   dislikes = 0 // Use renamed prop, default to 0
   // onVoteSuccess is removed from destructuring
 }: RealPowerBarVoteSystemProps) => {
+  console.log(`[RealPowerBarVoteSystem] RENDER articleId: ${articleId}, Props: likes=${likes}, dislikes=${dislikes}`);
   const { isDarkMode } = useTheme();
   const updateBlinkInList = useNewsStore(state => state.updateBlinkInList); // Get action from store
   // Local state for likes and dislikes removed
@@ -28,7 +29,7 @@ export const RealPowerBarVoteSystem = ({
   // This log can be very noisy. Add a useEffect below for more targeted prop logging.
 
   useEffect(() => {
-    console.log(`[RealPowerBarVoteSystem] Props updated for articleId: ${articleId} - Likes: ${likes}, Dislikes: ${dislikes}, UserVote: ${userVote}`);
+    console.log(`[RealPowerBarVoteSystem] EFFECT Props updated or userVote changed for articleId: ${articleId} - Likes: ${likes}, Dislikes: ${dislikes}, UserVote: ${userVote}`);
   }, [articleId, likes, dislikes, userVote]);
 
   const total = likes + dislikes; // Now uses props


### PR DESCRIPTION
To further diagnose why vote counts may not be updating visually after a vote, this commit adds an unconditional console.log at the beginning of the `RealPowerBarVoteSystem` component function.

This log will output the `articleId`, `likes` prop, and `dislikes` prop every time the component renders. This will help verify if the component is re-rendering with updated vote props after the Zustand store changes, or if new props are not being successfully passed down to it.

The existing useEffect log for prop/state changes has also been slightly reworded for clarity.