### PR TITLE
Fix(frontend): Definitively rewrite Index.tsx and RealPowerBarVoteSys…

### DIFF
--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -1,38 +1,32 @@
-
-import { useState, useEffect } from 'react'; // Ensure useEffect is imported
+import { useState, useEffect } from 'react'; // useEffect is used for logging prop changes
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
-import { voteOnArticle, NewsItem, transformBlinkToNewsItem } from '@/utils/api'; // Imported NewsItem and transformBlinkToNewsItem
-import { useNewsStore } from '../store/newsStore'; // Corrected import path
+import { voteOnArticle, NewsItem, transformBlinkToNewsItem } from '@/utils/api';
+import { useNewsStore } from '../store/newsStore';
 
 interface RealPowerBarVoteSystemProps {
   articleId: string;
-  likes?: number; // Renamed from initialLikes
-  dislikes?: number; // Renamed from initialDislikes
-  // onVoteSuccess prop is removed
+  likes?: number;
+  dislikes?: number;
 }
 
 export const RealPowerBarVoteSystem = ({ 
   articleId, 
-  likes = 0, // Use renamed prop, default to 0
-  dislikes = 0 // Use renamed prop, default to 0
-  // onVoteSuccess is removed from destructuring
+  likes = 0,
+  dislikes = 0
 }: RealPowerBarVoteSystemProps) => {
-  console.log(`[RealPowerBarVoteSystem] RENDER articleId: ${articleId}, Props: likes=${likes}, dislikes=${dislikes}`);
+  console.log(`[RealPowerBarVoteSystem] RENDER articleId: ${articleId}, Props: likes=${likes}, dislikes=${dislikes}`); // Diagnostic log
   const { isDarkMode } = useTheme();
-  const updateBlinkInList = useNewsStore(state => state.updateBlinkInList); // Get action from store
-  // Local state for likes and dislikes removed
+  const updateBlinkInList = useNewsStore(state => state.updateBlinkInList);
+
   const [userVote, setUserVote] = useState<'like' | 'dislike' | null>(null);
   const [isVoting, setIsVoting] = useState(false);
-
-  // console.log(`[RealPowerBarVoteSystem] Render for articleId: ${articleId}, Likes: ${likes}, Dislikes: ${dislikes}, UserVote: ${userVote}`);
-  // This log can be very noisy. Add a useEffect below for more targeted prop logging.
 
   useEffect(() => {
     console.log(`[RealPowerBarVoteSystem] EFFECT Props updated or userVote changed for articleId: ${articleId} - Likes: ${likes}, Dislikes: ${dislikes}, UserVote: ${userVote}`);
   }, [articleId, likes, dislikes, userVote]);
 
-  const total = likes + dislikes; // Now uses props
+  const total = likes + dislikes;
   const likePercentage = total > 0 ? (likes / total) * 100 : 0;
 
   const handleVote = async (voteType: 'like' | 'dislike', event: React.MouseEvent) => {
@@ -41,13 +35,11 @@ export const RealPowerBarVoteSystem = ({
     console.log(`[RealPowerBarVoteSystem] Current props: likes=${likes}, dislikes=${dislikes}`);
     console.log(`[RealPowerBarVoteSystem] Current state: userVote=${userVote}, isVoting=${isVoting}`);
 
-    // Restore original guard: if it's the current vote, or if already voting, do nothing.
     if (userVote === voteType || isVoting) {
       console.log(`[RealPowerBarVoteSystem] Vote attempt blocked: userVote=${userVote}, voteType=${voteType}, isVoting=${isVoting}`);
       return;
     }
 
-    // Store pre-vote state for userVote only
     const prevUserVote = userVote;
 
     let logOptimisticLikes = likes;
@@ -55,21 +47,18 @@ export const RealPowerBarVoteSystem = ({
     if (voteType === 'like') {
       logOptimisticLikes = likes + 1;
       if (userVote === 'dislike') {
-        logOptimisticDislikes = dislikes -1 < 0 ? 0 : dislikes - 1; // Ensure not negative
+        logOptimisticDislikes = dislikes -1 < 0 ? 0 : dislikes - 1;
       }
     } else { // voteType === 'dislike'
       logOptimisticDislikes = dislikes + 1;
       if (userVote === 'like') {
-        logOptimisticLikes = likes - 1 < 0 ? 0 : likes - 1; // Ensure not negative
+        logOptimisticLikes = likes - 1 < 0 ? 0 : likes - 1;
       }
     }
     console.log(`[RealPowerBarVoteSystem] Calculated optimistic update: likes=${logOptimisticLikes}, dislikes=${logOptimisticDislikes}. (User's previous vote: ${userVote}, current action: ${voteType})`);
 
     setIsVoting(true);
-
-    // Optimistic UI Update for userVote only
-    // Actual like/dislike counts will come from props updated by the store
-    setUserVote(voteType);
+    setUserVote(voteType); // Optimistic UI for user's own action
 
     try {
       const updatedArticleData = await voteOnArticle(articleId, voteType);
@@ -78,20 +67,15 @@ export const RealPowerBarVoteSystem = ({
       if (updatedArticleData) {
         const finalUpdatedBlink = transformBlinkToNewsItem(updatedArticleData);
         console.log(`[RealPowerBarVoteSystem] Transformed data for store update: ID=${finalUpdatedBlink.id}, Likes=${finalUpdatedBlink.votes?.likes}, Dislikes=${finalUpdatedBlink.votes?.dislikes}`);
-        // The component now relies on props for likes/dislikes.
-        // The store update will trigger a re-render with new props.
         updateBlinkInList(finalUpdatedBlink);
-        // setUserVote is already optimistically set. Could re-set if server could deny vote type.
-        // For now, assume optimistic userVote is fine.
+        // setUserVote already optimistically set.
       } else {
-        // API call failed or returned null, revert optimistic userVote update
         console.error('[RealPowerBarVoteSystem] Vote API call failed or returned null data. Reverting optimistic userVote update.');
-        setUserVote(prevUserVote);
+        setUserVote(prevUserVote); // Revert userVote if API call failed
       }
     } catch (error) {
       console.error(`[RealPowerBarVoteSystem] Error during voting process in handleVote for articleId: ${articleId}:`, error);
-      // Revert optimistic userVote update on any unexpected error
-      setUserVote(prevUserVote);
+      setUserVote(prevUserVote); // Revert userVote on error
     } finally {
       setIsVoting(false);
       console.log(`[RealPowerBarVoteSystem] handleVote finally block. isVoting set to false for articleId: ${articleId}`);

--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -1,5 +1,4 @@
-
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react'; // useState will be unused for heroNews but might be used by other parts if any, useEffect is used by loadNews
 import { Header } from '@/components/Header';
 import { Newsletter } from '@/components/Newsletter';
 import { Footer } from '@/components/ui/footer';
@@ -22,22 +21,16 @@ const Index = () => {
     activeTab,
     setActiveTab,
     clearFilters
-  } = useNewsFilter(news, 'tendencias'); // Changed 'ultimas' to 'tendencias'
+  } = useNewsFilter(news, 'tendencias');
 
+  // heroNews is derived directly from filteredNews
   const heroNews = filteredNews.length > 0 ? filteredNews[0] : null;
 
-  // REMOVED:
-  // useEffect(() => {
-  //   loadNews('ultimas');
-  // }, []);
-
   useEffect(() => {
-    if (activeTab) { // Ensure activeTab is truthy before loading
+    if (activeTab) {
       loadNews(activeTab);
     }
-  }, [activeTab, loadNews]); // loadNews is from useRealNews
-
-  // useEffect for setHeroNews removed
+  }, [activeTab, loadNews]);
 
   const handleRefresh = () => {
     refreshNews(activeTab);


### PR DESCRIPTION
…tem.tsx

This commit explicitly rewrites the contents of:
- news-blink-frontend/src/pages/Index.tsx
- news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx

The new contents ensure these components adhere to the corrected logic that was previously implemented (in commit `fix/frontend-state-sync`):

1.  `Index.tsx`:
    - `heroNews` is derived directly from `filteredNews`.
    - Local `useState` and `useEffect` for managing `heroNews` have been definitively removed.

2.  `RealPowerBarVoteSystem.tsx`:
    - `likes` and `dislikes` are received and used directly as props.
    - Local `useState` for managing these vote counts internally has been definitively removed. (Local state for `userVote` and `isVoting` remains, which is correct).

This action is taken to eliminate any uncertainty about whether these foundational frontend state management fixes are present in the codebase you are testing. All previously added diagnostic console logs within these files are preserved.