### PR TITLE
Fix(backend): Ensure /api/blinks always returns votes field for all i…

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -256,6 +256,17 @@ def get_all_blinks_sorted():
         try:
             with open(blink_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
+
+                # Ensure 'votes' field exists with a default structure
+                if 'votes' not in data or not isinstance(data['votes'], dict):
+                    data['votes'] = {'likes': 0, 'dislikes': 0}
+                else:
+                    # Ensure 'likes' and 'dislikes' keys exist within data['votes']
+                    if 'likes' not in data['votes']:
+                        data['votes']['likes'] = 0
+                    if 'dislikes' not in data['votes']:
+                        data['votes']['dislikes'] = 0
+
                 all_blinks_data.append(data)
 
                 if logged_count < max_logs:


### PR DESCRIPTION
…tems

This commit addresses an issue where the GET /api/blinks endpoint (handled by `get_all_blinks_sorted` in `routes/api.py`) could return blink objects that were missing the `votes` field if the corresponding JSON file on disk did not contain this key.

When your frontend's `fetchNews` processed this list, items without a `votes` field would have their votes defaulted to `{likes:0, dislikes:0}` by `transformBlinkToNewsItem`. This was correct behavior by the transformer, but if a full list refresh occurred after an individual item's votes were updated (and written to its file with a proper `votes` field by `vote_on_blink`), the stale data from other files (still missing `votes`) could cause your UI to appear as if all votes were reset to 0/0.

The `get_all_blinks_sorted` function has been modified:
- After loading a blink's data from its JSON file, it now checks if the `votes` field is present and is a dictionary.
- If not, `data['votes']` is initialized to `{'likes': 0, 'dislikes': 0}`.
- It further ensures that `likes` and `dislikes` keys exist within `data['votes']`, defaulting them to 0 if they are missing.

This ensures that every blink object returned by `/api/blinks` will consistently have a `votes` object with `likes` and `dislikes` keys, providing a stable data structure to your frontend and preventing the issue where votes appeared to be reset across the list.