### PR TITLE
Fix: Correct prop names for vote counts in FuturisticNewsCard

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -160,8 +160,8 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
           <div className="flex-shrink-0">
             <RealPowerBarVoteSystem
               articleId={news.id}
-              initialLikes={news.votes?.likes || 0}
-              initialDislikes={news.votes?.dislikes || 0}
+              likes={news.votes?.likes || 0}
+              dislikes={news.votes?.dislikes || 0}
             />
           </div>
         </div>


### PR DESCRIPTION
The RealPowerBarVoteSystem component was receiving vote counts via props named `initialLikes` and `initialDislikes` from its parent FuturisticNewsCard. However, RealPowerBarVoteSystem expected these props to be named `likes` and `dislikes`.

This mismatch caused RealPowerBarVoteSystem to use its default prop values (0) for likes and dislikes, leading to the UI not displaying the correct vote counts even after the state store was updated.

This commit renames the props in FuturisticNewsCard.tsx when rendering RealPowerBarVoteSystem to `likes` and `dislikes` to match what the child component expects.