### PR TITLE
Fix: Detail page votes and refined zero-like sort order

### DIFF
--- a/news-blink-frontend/src/components/KeyPointsSidebar.tsx
+++ b/news-blink-frontend/src/components/KeyPointsSidebar.tsx
@@ -128,8 +128,8 @@ export function KeyPointsSidebar({ article }: KeyPointsSidebarProps) {
       <div className="pt-6 border-t border-gray-200 dark:border-gray-800">
         <RealPowerBarVoteSystem
           articleId={article.id}
-          initialLikes={article.votes?.likes || 0}
-          initialDislikes={article.votes?.dislikes || 0}
+          likes={article.votes?.likes || 0}
+          dislikes={article.votes?.dislikes || 0}
         />
       </div>
 


### PR DESCRIPTION
This commit addresses two issues:

1.  Article Detail Page Vote Discrepancy:
    - Modified `KeyPointsSidebar.tsx` to pass `likes` and `dislikes` props correctly to `RealPowerBarVoteSystem`.
    - Updated `BlinkDetail.tsx` to prioritize article data from `newsStore` if available, ensuring vote counts are consistent with the main feed. It falls back to fetching directly if the article isn't in the store.

2.  Refined Sorting Logic for Zero-Like Articles:
    - Updated the `sortBlinks` function in `newsStore.ts`.
    - Articles with positive likes are now explicitly prioritized over articles with zero likes.
    - Articles with zero likes are sorted amongst themselves first by the number of dislikes (ascending - fewer is better), and then by publication date (descending - newer is better).
    - Articles with positive likes continue to be sorted by aiScore (desc), then dislikes (asc), then date (desc).