### PR TITLE
Fix: Hero card votes and add detailed sort logging

### DIFF
--- a/news-blink-frontend/src/components/FuturisticHeroCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticHeroCard.tsx
@@ -158,8 +158,8 @@ export const FuturisticHeroCard = memo(({ news, onCardClick }: FuturisticHeroCar
             <div onClick={(e) => e.stopPropagation()}>
               <RealPowerBarVoteSystem // Changed component
                 articleId={news.id}
-                initialLikes={news.votes?.likes || 0}
-                initialDislikes={news.votes?.dislikes || 0}
+                likes={news.votes?.likes || 0}
+                dislikes={news.votes?.dislikes || 0}
               />
             </div>
           </div>

--- a/news-blink-frontend/src/store/newsStore.ts
+++ b/news-blink-frontend/src/store/newsStore.ts
@@ -42,13 +42,27 @@ const sortBlinks = (blinks: NewsItem[], sortBy: 'hot' | 'latest'): NewsItem[] =>
 
       // If both items have 0 likes
       if (likesA === 0 && likesB === 0) {
+        if (hotSortLogCount <= maxHotSortLogs) { // Continue using existing log count condition
+            console.log(`    [0-Likes Group] Comparing A (id=${a.id}, dislikes=${dislikesA}, date=${new Date(dateA).toISOString()}) vs B (id=${b.id}, dislikes=${dislikesB}, date=${new Date(dateB).toISOString()})`);
+        }
         // Sort by number of dislikes (ascending - fewer dislikes are better)
         const dislikeDiff = dislikesA - dislikesB;
+        if (hotSortLogCount <= maxHotSortLogs) {
+            console.log(`      [0-Likes Group] dislikeDiff (A-B): ${dislikeDiff}`);
+        }
         if (dislikeDiff !== 0) {
           return dislikeDiff;
         }
+
         // If dislikes are equal, sort by publication date (descending - newer is better)
-        return dateB - dateA;
+        if (hotSortLogCount <= maxHotSortLogs) {
+            console.log(`      [0-Likes Group] Dislikes equal. Comparing dates (B-A). Date A: ${new Date(dateA).toISOString()}, Date B: ${new Date(dateB).toISOString()}`);
+        }
+        const dateDiffResult = dateB - dateA;
+        if (hotSortLogCount <= maxHotSortLogs) {
+            console.log(`      [0-Likes Group] dateDiffResult (B-A): ${dateDiffResult}`);
+        }
+        return dateDiffResult;
       }
 
       // If both items have positive likes (implicit from the checks above)


### PR DESCRIPTION
This commit includes:
1.  FuturisticHeroCard prop fix:
    - Changed `initialLikes` to `likes` and `initialDislikes` to `dislikes` when rendering `RealPowerBarVoteSystem` in `FuturisticHeroCard.tsx` to ensure correct vote display.

2.  Enhanced sorting diagnostics:
    - Added detailed console logs to the `sortBlinks` function in `newsStore.ts` specifically for the logic path that compares articles with zero likes. This will help in diagnosing any remaining issues with their sort order.