### PR TITLE
Fix: Align tendecias sort and trace hero data

### DIFF
--- a/news-blink-frontend/src/components/FuturisticHeroCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticHeroCard.tsx
@@ -10,6 +10,11 @@ interface FuturisticHeroCardProps {
 }
 
 export const FuturisticHeroCard = memo(({ news, onCardClick }: FuturisticHeroCardProps) => {
+  if (news) { // 'news' is the prop name in FuturisticHeroCard
+    console.log(`[FuturisticHeroCard.tsx] Received news prop: ID=${news.id}, Likes=${news.votes?.likes}, Dislikes=${news.votes?.dislikes}`);
+  } else {
+    console.log('[FuturisticHeroCard.tsx] Received news prop is null');
+  }
   const { isDarkMode } = useTheme();
   const [currentBullet, setCurrentBullet] = useState(0);
   const [isHovered, setIsHovered] = useState(false);

--- a/news-blink-frontend/src/components/NewsContent.tsx
+++ b/news-blink-frontend/src/components/NewsContent.tsx
@@ -37,6 +37,11 @@ export const NewsContent = ({
   clearFilters,
   onCardClick
 }: NewsContentProps) => {
+  if (heroNews) {
+    console.log(`[NewsContent.tsx] Received heroNews: ID=${heroNews.id}, Likes=${heroNews.votes?.likes}, Dislikes=${heroNews.votes?.dislikes}`);
+  } else {
+    console.log('[NewsContent.tsx] Received heroNews is null');
+  }
   const { isDarkMode } = useTheme();
 
   if (loading) {

--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -62,32 +62,7 @@ export const useNewsFilter = (news: any[], initialActiveTab: string = 'tendencia
     // console.log('[useNewsFilter] Inside tabFilteredNews memo. Start. categoryFilteredNews length:', categoryFilteredNews.length, 'activeTab:', activeTab); // Optional inner log
     switch (activeTab) {
       case 'tendencias':
-        filtered.sort((a, b) => {
-          const votesA = a.votes || { likes: 0, dislikes: 0 };
-          const likesA = Number(votesA.likes || 0);
-          const dislikesA = Number(votesA.dislikes || 0);
-          const totalVotesA = likesA + dislikesA;
-          const scoreA = totalVotesA > 0 ? likesA / totalVotesA : 0.0;
-
-          const votesB = b.votes || { likes: 0, dislikes: 0 };
-          const likesB = Number(votesB.likes || 0);
-          const dislikesB = Number(votesB.dislikes || 0);
-          const totalVotesB = likesB + dislikesB;
-          const scoreB = totalVotesB > 0 ? likesB / totalVotesB : 0.0;
-
-          if (scoreB !== scoreA) {
-            return scoreB - scoreA; // Primary: interest score descending
-          }
-
-          if (likesB !== likesA) {
-            return likesB - likesA; // Secondary: absolute likes descending
-          }
-
-          // Tertiary: publishedAt (timestamp) descending
-          const timestampA = new Date(a.publishedAt || 0).getTime();
-          const timestampB = new Date(b.publishedAt || 0).getTime();
-          return timestampB - timestampA;
-        });
+        // No custom sort needed here, as categoryFilteredNews is already sorted by newsStore's sortBlinks
         break;
       case 'rumores':
         filtered = filtered.filter(item => item.category === 'RUMORES' || item.aiScore < 90);

--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -26,6 +26,12 @@ const Index = () => {
   // heroNews is derived directly from filteredNews
   const heroNews = filteredNews.length > 0 ? filteredNews[0] : null;
 
+  if (heroNews) {
+    console.log(`[Index.tsx] heroNews selected: ID=${heroNews.id}, Likes=${heroNews.votes?.likes}, Dislikes=${heroNews.votes?.dislikes}`);
+  } else {
+    console.log('[Index.tsx] heroNews is null');
+  }
+
   useEffect(() => {
     if (activeTab) {
       loadNews(activeTab);


### PR DESCRIPTION
This commit addresses two main points:

1.  Corrected Sorting for "Tendencias" Tab:
    - Removed the custom client-side sorting logic within the `useNewsFilter.ts` hook for the "tendencias" (trending) tab.
    - This tab now correctly inherits the sorting order established by the `sortBlinks` function in `newsStore.ts` (which prioritizes items with likes, then for zero-like items sorts by fewer dislikes, then by date). This ensures consistent sorting logic.

2.  Added Hero Article Data Tracing:
    - Implemented console logs in `Index.tsx`, `NewsContent.tsx`, and `FuturisticHeroCard.tsx` to output the properties (ID, votes) of the `heroNews` object as it's passed down. This will help in diagnosing any remaining discrepancies in the featured article's vote display.