### PR TITLE
Fix: Resolve TypeError in RealPowerBarVoteSystem

### DIFF
--- a/news-blink-frontend/src/components/FuturisticHeroCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticHeroCard.tsx
@@ -161,11 +161,7 @@ export const FuturisticHeroCard = memo(({ news, onCardClick }: FuturisticHeroCar
 
             {/* Vote system */}
             <div onClick={(e) => e.stopPropagation()}>
-              <RealPowerBarVoteSystem // Changed component
-                articleId={news.id}
-                likes={news.votes?.likes || 0}
-                dislikes={news.votes?.dislikes || 0}
-              />
+              <RealPowerBarVoteSystem news={news} />
             </div>
           </div>
         </div>

--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -158,13 +158,7 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
           
           {/* Vote system at bottom */}
           <div className="flex-shrink-0">
-            <RealPowerBarVoteSystem
-              articleId={news.id}
-              positiveVotes={news.votes?.positive || 0}
-              negativeVotes={news.votes?.negative || 0}
-              currentUserVoteStatus={news.currentUserVoteStatus || null}
-              interestPercentage={news.interestPercentage || 0}
-            />
+            <RealPowerBarVoteSystem news={news} />
           </div>
         </div>
       </div>

--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -16,17 +16,17 @@ export const RealPowerBarVoteSystem = ({ news }: RealPowerBarVoteSystemProps) =>
 
   // Internal state for UI responsiveness and optimistic updates
   // Derives initial state from the `news` prop
-  const [internalUserVote, setInternalUserVote] = useState(news.currentUserVoteStatus);
+  const [internalUserVote, setInternalUserVote] = useState(news?.currentUserVoteStatus ?? null);
   const [isVoting, setIsVoting] = useState(false);
-  const [optimisticLikes, setOptimisticLikes] = useState(news.votes?.likes ?? 0);
-  const [optimisticDislikes, setOptimisticDislikes] = useState(news.votes?.dislikes ?? 0);
+  const [optimisticLikes, setOptimisticLikes] = useState(news?.votes?.likes ?? 0);
+  const [optimisticDislikes, setOptimisticDislikes] = useState(news?.votes?.dislikes ?? 0);
 
   // Effect to sync internal state when the news prop changes externally
   useEffect(() => {
-    setInternalUserVote(news.currentUserVoteStatus);
-    setOptimisticLikes(news.votes?.likes ?? 0);
-    setOptimisticDislikes(news.votes?.dislikes ?? 0);
-  }, [news.currentUserVoteStatus, news.votes?.likes, news.votes?.dislikes, news.id]);
+    setInternalUserVote(news?.currentUserVoteStatus ?? null);
+    setOptimisticLikes(news?.votes?.likes ?? 0);
+    setOptimisticDislikes(news?.votes?.dislikes ?? 0);
+  }, [news?.currentUserVoteStatus, news?.votes?.likes, news?.votes?.dislikes, news?.id]);
 
   // Interest percentage is now calculated on the frontend if needed for display here
   // For this component, we might only display the power bar based on likes/dislikes ratio
@@ -38,6 +38,14 @@ export const RealPowerBarVoteSystem = ({ news }: RealPowerBarVoteSystemProps) =>
 
   const handleVote = async (newVoteType: 'like' | 'dislike', event: React.MouseEvent) => {
     event.stopPropagation();
+
+    if (!news || !news.id) {
+      console.error("[RealPowerBarVoteSystem] Attempted to vote with invalid news item:", news);
+      toast.error("Cannot vote: news item data is missing.");
+      // setIsVoting(false); // isVoting is already false or will be set in finally
+      return;
+    }
+
     if (isVoting) return;
 
     const previousVote = internalUserVote; // This is 'like', 'dislike', or null
@@ -114,7 +122,7 @@ export const RealPowerBarVoteSystem = ({ news }: RealPowerBarVoteSystemProps) =>
     }
   };
 
-  const interestPercentageForDisplay = news.interestPercentage !== undefined ? Math.round(news.interestPercentage) : 'N/A';
+  const interestPercentageForDisplay = news?.interestPercentage !== undefined ? Math.round(news.interestPercentage) : 'N/A';
 
 
   return (


### PR DESCRIPTION
This commit addresses a TypeError "Cannot read properties of undefined (reading 'currentUserVoteStatus')" occurring in the RealPowerBarVoteSystem component.

The root cause was that parent components (FuturisticHeroCard and FuturisticNewsCard) were passing individual props (articleId, likes, etc.) to RealPowerBarVoteSystem instead of the expected single 'news' object prop.

Changes:
1.  Modified FuturisticHeroCard.tsx to pass the entire 'news' object to RealPowerBarVoteSystem: `<RealPowerBarVoteSystem news={news} />`.
2.  Modified FuturisticNewsCard.tsx similarly to pass the entire 'news' object.
3.  Earlier, defensive checks were added to RealPowerBarVoteSystem.tsx itself (using optional chaining and nullish coalescing for properties like `news?.currentUserVoteStatus`) to make it more resilient against incomplete props, although the primary fix is the correct prop passing.

These changes ensure that RealPowerBarVoteSystem receives the complete NewsItem object, including 'currentUserVoteStatus' and the 'votes' object, thus preventing the runtime error.