### PR TITLE
Fix: Correct store method call in RealPowerBarVoteSystem

### DIFF
--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -12,7 +12,7 @@ interface RealPowerBarVoteSystemProps {
 export const RealPowerBarVoteSystem = ({ news }: RealPowerBarVoteSystemProps) => {
   const { isDarkMode } = useTheme();
   // Ensure updateArticleVotes is correctly typed in the store if it expects specific vote structure
-  const { updateArticleVotes } = useNewsStore();
+  const { updateBlinkInList } = useNewsStore();
 
   // Internal state for UI responsiveness and optimistic updates
   // Derives initial state from the `news` prop
@@ -95,11 +95,7 @@ export const RealPowerBarVoteSystem = ({ news }: RealPowerBarVoteSystemProps) =>
 
       if (updatedArticleData && updatedArticleData.votes) {
         // Update the Zustand store with the data from the API response
-        updateArticleVotes(
-          updatedArticleData.id,
-          updatedArticleData.votes, // This is now { likes: number, dislikes: number }
-          updatedArticleData.currentUserVoteStatus // This is now 'like', 'dislike', or null
-        );
+        updateBlinkInList(updatedArticleData);
         toast.success(`Voto '${newVoteType}' registrado!`);
         // Internal state will be synced by useEffect when news prop updates
       } else {


### PR DESCRIPTION
This commit resolves a TypeError "updateArticleVotes is not a function" that occurred in the RealPowerBarVoteSystem component.

The issue was caused by the component attempting to call a non-existent `updateArticleVotes` function from the `useNewsStore`. The store actually provides a method named `updateBlinkInList` for updating a single news item.

Changes:
- Modified `RealPowerBarVoteSystem.tsx` to destructure `updateBlinkInList` from `useNewsStore()`.
- Updated the `handleVote` function within `RealPowerBarVoteSystem.tsx` to call `updateBlinkInList(updatedArticleData)` with the `NewsItem` object returned from the API, which is the expected argument format for the store's update method.