### PR TITLE
Fix: Ensure interest percentage display and data integrity for sorting

### DIFF
--- a/models/news.py
+++ b/models/news.py
@@ -351,13 +351,35 @@ class News:
                     blink['currentUserVoteStatus'] = self._get_user_vote_status(blink, user_id) # Uses like/dislike now
                 else:
                     blink['currentUserVoteStatus'] = None
+
+                # Refined logging for interest percentage
+                interest_to_log = blink.get('interestPercentage')
+                interest_log_str = f"{interest_to_log:.2f}%" if isinstance(interest_to_log, float) else str(interest_to_log)
+                app_logger.debug(
+                    f"[GET_ALL_BLINKS_PRE_SORT] ID: {blink.get('id')}, "
+                    f"Votes: L={blink.get('votes', {}).get('likes', 0)} / D={blink.get('votes', {}).get('dislikes', 0)}, "
+                    f"Interest: {interest_log_str}, "
+                    f"Published: {blink.get('publishedAt')}, "
+                    f"UserVote: {blink.get('currentUserVoteStatus')}"
+                )
                 blinks_processed.append(blink)
-                # Updated log to include interest and reflect L/D votes
-                app_logger.debug(f"Processed blink_id='{blink.get('id')}': UserVote='{blink['currentUserVoteStatus']}', Votes(L/D): {current_votes.get('likes',0)}/{current_votes.get('dislikes',0)}, Interest: {blink.get('interestPercentage', 'N/A')}")
+                # Original log below can be kept or removed if the new one is sufficient
+                # app_logger.debug(f"Processed blink_id='{blink.get('id')}': UserVote='{blink['currentUserVoteStatus']}', Votes(L/D): {current_votes.get('likes',0)}/{current_votes.get('dislikes',0)}, Interest: {blink.get('interestPercentage', 'N/A')}")
             except Exception as e:
                 app_logger.error(f"Error processing blink file {filename} in get_all_blinks loop: {e}", exc_info=True)
 
         app_logger.info(f"Sorting {len(blinks_processed)} blinks based on dynamic interest and rules.")
         blinks_processed.sort(key=cmp_to_key(self._compare_blinks))
+
+        app_logger.debug("[GET_ALL_BLINKS_POST_SORT] First 5 items after sorting:")
+        for i, sorted_blink in enumerate(blinks_processed[:5]):
+            interest_to_log_sorted = sorted_blink.get('interestPercentage')
+            interest_log_str_sorted = f"{interest_to_log_sorted:.2f}%" if isinstance(interest_to_log_sorted, float) else str(interest_to_log_sorted)
+            app_logger.debug(
+                f"  {i+1}. ID: {sorted_blink.get('id')}, "
+                f"Interest: {interest_log_str_sorted}, "
+                f"Published: {sorted_blink.get('publishedAt')}"
+            )
+
         app_logger.info(f"Successfully processed, loaded and sorted {len(blinks_processed)} blinks.")
         return blinks_processed

--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -27,9 +27,13 @@ const Index = () => {
   const heroNews = filteredNews.length > 0 ? filteredNews[0] : null;
 
   if (heroNews) {
-    console.log(`[Index.tsx] heroNews selected: ID=${heroNews.id}, Likes=${heroNews.votes?.likes}, Dislikes=${heroNews.votes?.dislikes}`);
+    console.log(`[Index.tsx] heroNews selected: ID=${heroNews.id}, Likes=${heroNews.votes?.likes}, Dislikes=${heroNews.votes?.dislikes}, Interest=${heroNews.interestPercentage}`);
   } else {
     console.log('[Index.tsx] heroNews is null');
+  }
+
+  if (filteredNews.length > 0) {
+    console.log('[Index.tsx] filteredNews (first 3 with id, votes, interestPercentage):', filteredNews.slice(0, 3).map(item => ({id: item.id, votes: item.votes, interestPercentage: item.interestPercentage })));
   }
 
   useEffect(() => {

--- a/news-blink-frontend/src/store/newsStore.ts
+++ b/news-blink-frontend/src/store/newsStore.ts
@@ -24,6 +24,7 @@ export const useNewsStore = create<NewsState>((set, get) => ({
     try {
       // apiFetchNews from utils/api.ts already passes userId and returns transformed, sorted NewsItem[]
       const fetchedNewsItems = await apiFetchNews();
+      console.log('[newsStore.ts fetchNews] NewsItems from apiFetchNews (first 3):', fetchedNewsItems?.slice(0, 3)?.map(item => ({ id: item.id, interestPercentage: item.interestPercentage, votes: item.votes })));
 
       // console.log(`[newsStore.ts] fetchNews - Fetched and transformed news (first 3 items):`, fetchedNewsItems.slice(0,3));
       // fetchedNewsItems.slice(0,3).forEach((item: NewsItem, index: number) => {


### PR DESCRIPTION
This commit addresses issues where interest percentage was displaying as "N/A" and potentially contributing to blinks not appearing sorted as expected.

Changes include:
1.  Frontend Data Handling (`utils/api.ts`):
    - Modified `transformBlinkToNewsItem` to ensure that `NewsItem.interestPercentage` defaults to `0.0` if the value from the backend is not a valid number.
    - Updated the `NewsItem` interface to define `interestPercentage: number;` (non-optional after transformation), reflecting this guaranteed numeric value.
    - Updated an outdated comment in the `NewsItem` interface regarding backend provision of `interestPercentage`.
2.  Logging for Diagnostics:
    - Added detailed logging in `models/news.py` (backend) to output calculated `interestPercentage` values before and after sorting.
    - Added comprehensive logging across the frontend data flow (`utils/api.ts`, `store/newsStore.ts`, `hooks/useNewsFilter.ts`, `pages/Index.tsx`) to trace the `interestPercentage` field.

These changes ensure that the frontend always has a valid numeric `interestPercentage` for display (fixing "N/A") and for any potential client-side logic (though primary sorting is backend-driven). The added logging will help diagnose any further discrepancies in interest calculation or sorting behavior.