### PR TITLE
To make sure the news list re-sorts after you vote, I've updated `Rea…

### DIFF
--- a/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/RealPowerBarVoteSystem.tsx
@@ -12,7 +12,7 @@ interface RealPowerBarVoteSystemProps {
 export const RealPowerBarVoteSystem = ({ news }: RealPowerBarVoteSystemProps) => {
   const { isDarkMode } = useTheme();
   // Ensure updateArticleVotes is correctly typed in the store if it expects specific vote structure
-  const { updateBlinkInList } = useNewsStore();
+  const { fetchNews } = useNewsStore();
 
   // Internal state for UI responsiveness and optimistic updates
   // Derives initial state from the `news` prop
@@ -95,7 +95,7 @@ export const RealPowerBarVoteSystem = ({ news }: RealPowerBarVoteSystemProps) =>
 
       if (updatedArticleData && updatedArticleData.votes) {
         // Update the Zustand store with the data from the API response
-        updateBlinkInList(updatedArticleData);
+        fetchNews(); // Add this line
         toast.success(`Voto '${newVoteType}' registrado!`);
         // Internal state will be synced by useEffect when news prop updates
       } else {


### PR DESCRIPTION
…lPowerBarVoteSystem.tsx`. Now, it will fetch all news items again after a successful vote. This means the frontend will always show the latest list of blinks, sorted by the backend based on the new interest percentages. This is an improvement over the previous approach, which only updated the single item you voted on in the local store.