### PR TITLE
I've fixed the import names in `newsStore.ts` for the API functions.

### DIFF
--- a/news-blink-frontend/src/store/newsStore.ts
+++ b/news-blink-frontend/src/store/newsStore.ts
@@ -1,7 +1,7 @@
 // news-blink-frontend/src/store/newsStore.ts
 
 import { create } from 'zustand';
-import { fetchBlinks as apiFetchBlinks, voteOnBlink as apiVoteOnBlink } from '../utils/api';
+import { fetchNews as apiFetchBlinks, voteOnArticle as apiVoteOnBlink } from '../utils/api';
 // Import Blink type from types/newsTypes.ts instead of defining it here
 import { Blink } from '../types/newsTypes';
 export type { Blink }; // Re-export Blink for use in other modules


### PR DESCRIPTION
I corrected the import statement in `news-blink-frontend/src/store/newsStore.ts` to use the correct function names exported by `news-blink-frontend/src/utils/api.ts`.

- I changed the import of `fetchBlinks` to `fetchNews`.
- I changed the import of `voteOnBlink` to `voteOnArticle`.

This should resolve the runtime errors caused by mismatched import names.