### PR TITLE
I've fixed the "Cannot read properties of undefined (reading 'length'…

### DIFF
--- a/news-blink-frontend/src/hooks/useNewsFilter.ts
+++ b/news-blink-frontend/src/hooks/useNewsFilter.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { NewsItem } from '../utils/api'; // Import NewsItem
 
-export const useNewsFilter = (news: NewsItem[], initialActiveTab: string = 'tendencias') => {
+export const useNewsFilter = (news: NewsItem[] = [], initialActiveTab: string = 'tendencias') => {
   console.log(`[useNewsFilter] Hook execution. Input 'news' array length: ${news.length}. Backend now handles sorting.`);
   if (news.length > 0 && typeof news.slice === 'function') {
     console.log(`[useNewsFilter] Input 'news' (first 3 items with id, votes, interestPercentage, publishedAt):`, news.slice(0, 3).map(item => ({id: item.id, votes: item.votes, interestPercentage: item.interestPercentage, publishedAt: item.publishedAt })));


### PR DESCRIPTION
…)" error in `news-blink-frontend/src/hooks/useNewsFilter.ts`. This happened because the `news` parameter was sometimes undefined during the initial rendering of the component.

To address this, I've modified the `useNewsFilter.ts` file to give the `news` parameter a default empty array (`[]`). This ensures the hook handles cases where `news` might be undefined, making it more robust.