### PR TITLE
Fix: Ensure news summary is handled robustly to prevent errors.

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -28,7 +28,7 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
   }, []);
 
   // Simulación de "key points" a partir del resumen, como en el original.
-  const points = news.summary.split('. ').filter(p => p.length > 5).slice(0, 3);
+  const points = (news.summary || '').split('. ').filter(p => p.length > 5).slice(0, 3);
 
   useEffect(() => {
     let interval: NodeJS.Timeout;

--- a/news-blink-frontend/src/utils/api.ts
+++ b/news-blink-frontend/src/utils/api.ts
@@ -64,6 +64,7 @@ export const transformBlinkToNewsItem = (blink: any): NewsItem => {
   return {
     id: blink.id || String(blink._id) || '', // Handle MongoDB _id if present
     title: blink.title || 'No Title Provided',
+    summary: blink.summary || '',
     image: blink.image || '/placeholder.svg', // Use a local placeholder
     points: Array.isArray(blink.points) ? blink.points : [],
     category: (Array.isArray(blink.categories) && blink.categories.length > 0 ? blink.categories[0] : blink.category) || 'general',
@@ -79,8 +80,7 @@ export const transformBlinkToNewsItem = (blink: any): NewsItem => {
     interestPercentage: typeof blink.interestPercentage === 'number' ? blink.interestPercentage : 0.0,
     currentUserVoteStatus: blink.currentUserVoteStatus === 'like' || blink.currentUserVoteStatus === 'dislike' ? blink.currentUserVoteStatus : null, // Ensure correct assignment
   };
-  // console.log(`[utils/api.ts transformBlinkToNewsItem] Output NewsItem (ID: ${transformedItem.id}): interestPercentage = ${transformedItem.interestPercentage}`);
-  return transformedItem;
+  // console.log(`[utils/api.ts transformBlinkToNewsItem] Output NewsItem (ID: ${blink.id}): interestPercentage = ${blink.interestPercentage}`);
 };
 
 export const fetchNews = async (): Promise<NewsItem[]> => {


### PR DESCRIPTION
Modified news-blink-frontend/src/components/FuturisticNewsCard.tsx to default `news.summary` to an empty string before calling `.split()`. This prevents runtime errors if `summary` is undefined.

Modified news-blink-frontend/src/utils/api.ts in the `transformBlinkToNewsItem` function to ensure that the `summary` field defaults to an empty string (`''`) if it's not provided or is falsy in the raw blink data from the backend. Also removed an erroneous duplicate return statement from this function.

These changes prevent "Cannot read properties of undefined (reading 'split')" errors and make data handling more resilient.