### PR TITLE
Fix: Correct import in RumorHeroCard.tsx.

### DIFF
--- a/news-blink-frontend/src/components/RumorHeroCard.tsx
+++ b/news-blink-frontend/src/components/RumorHeroCard.tsx
@@ -1,6 +1,6 @@
 
 import { Badge } from '@/components/ui/badge';
-import { RealPowerBarVoteSystem } from './RealPowerBarVoteSystem'; // Changed import
+import { PowerBarVoteSystem } from './PowerBarVoteSystem'; // Corrected import
 import { useState, useEffect, useCallback, memo } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Eye, MessageCircle } from 'lucide-react';
@@ -161,7 +161,7 @@ export const RumorHeroCard = memo(({ news, onCardClick }: RumorHeroCardProps) =>
 
               {/* Vote system */}
               <div onClick={(e) => e.stopPropagation()}>
-                <RealPowerBarVoteSystem // Changed component
+                <PowerBarVoteSystem // Corrected component
                   articleId={news.id}
                   initialLikes={news.votes?.likes || 0}
                   initialDislikes={news.votes?.dislikes || 0}


### PR DESCRIPTION
I corrected the import in news-blink-frontend/src/components/RumorHeroCard.tsx to use PowerBarVoteSystem instead of RealPowerBarVoteSystem, reflecting the recent renaming of the voting component.

Note: Persistent 'Unterminated string literal' errors in FuturisticNewsCard.tsx are suspected to be environment-related (caching/Docker sync) on your side, as the file content appears correct in the repository.