### PR TITLE
Fix: Resolve frontend build errors and warnings

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -175,4 +175,3 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
 });
 
 FuturisticNewsCard.displayName = 'FuturisticNewsCard';
-```

--- a/news-blink-frontend/src/components/KeyPointsSidebar.tsx
+++ b/news-blink-frontend/src/components/KeyPointsSidebar.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
-import { RealPowerBarVoteSystem } from '@/components/RealPowerBarVoteSystem';
+import { PowerBarVoteSystem } from '@/components/PowerBarVoteSystem';
 import { ComplementaryInfoCard } from '@/components/ComplementaryInfoCard';
 import { Target, TrendingUp, Lightbulb, AlertCircle } from 'lucide-react';
 import { NewsItem } from '@/utils/api';
@@ -126,7 +126,7 @@ export function KeyPointsSidebar({ article }: KeyPointsSidebarProps) {
       </div>
 
       <div className="pt-6 border-t border-gray-200 dark:border-gray-800">
-        <RealPowerBarVoteSystem
+        <PowerBarVoteSystem
           articleId={article.id}
           likes={article.votes?.likes || 0}
           dislikes={article.votes?.dislikes || 0}

--- a/news-blink-frontend/src/components/RumorCard.tsx
+++ b/news-blink-frontend/src/components/RumorCard.tsx
@@ -1,6 +1,6 @@
 
 import { Badge } from '@/components/ui/badge';
-import { RealPowerBarVoteSystem } from './RealPowerBarVoteSystem'; // Changed import
+import { PowerBarVoteSystem } from './PowerBarVoteSystem'; // Changed import
 import { useState, useCallback, memo } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { Eye, MessageCircle } from 'lucide-react';
@@ -128,7 +128,7 @@ export const RumorCard = memo(({ news, onCardClick }: RumorCardProps) => {
           
           {/* Vote system */}
           <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
-            <RealPowerBarVoteSystem // Changed component
+            <PowerBarVoteSystem // Changed component
               articleId={news.id}
               initialLikes={news.votes?.likes || 0}
               initialDislikes={news.votes?.dislikes || 0}


### PR DESCRIPTION
This commit addresses several issues that were causing build failures and warnings in your blink-news-frontend application:

1.  **Corrected Import Paths for PowerBarVoteSystem:**
    - Updated import statements in `news-blink-frontend/src/components/KeyPointsSidebar.tsx` and `news-blink-frontend/src/components/RumorCard.tsx`.
    - The component `PowerBarVoteSystem.tsx` was being incorrectly referred to as `RealPowerBarVoteSystem`.
    - Corrected both the import source and the component usage (e.g., `<RealPowerBarVoteSystem />` to `<PowerBarVoteSystem />`).

2.  **Fixed Syntax Error in FuturisticNewsCard.tsx:**
    - Removed an unterminated template literal caused by an extraneous "```" at the end of the file `news-blink-frontend/src/components/FuturisticNewsCard.tsx`. This resolved the `BABEL_PARSER_SYNTAX_ERROR` (UnterminatedTemplate).

3.  **Investigated Tailwind CSS Warning:**
    - The warning "The class duration-[2000ms] is ambiguous" was traced to `news-blink-frontend/src/components/AnimatedBackground.tsx`.
    - No changes were made as this is a warning and the class is likely functioning as intended.

These changes should allow the Vite pre-transform and build processes to complete successfully.