### PR TITLE
Fix: Prevent TypeError in BlinkDetail component

### DIFF
--- a/news-blink-frontend/src/pages/BlinkDetail.tsx
+++ b/news-blink-frontend/src/pages/BlinkDetail.tsx
@@ -15,7 +15,7 @@ export default function BlinkDetail() {
   const { id } = useParams<{ id: string }>();
   const { isDarkMode } = useTheme();
   const [fetchedArticle, setFetchedArticle] = useState<NewsItem | null>(null);
-  const articleFromStore = useNewsStore(state => state.news.find(a => a.id === id));
+  const articleFromStore = useNewsStore(state => (state.news || []).find(a => a.id === id));
   const article = articleFromStore || fetchedArticle;
   // Initialize loading to true only if we don't have the article from store initially
   const [loading, setLoading] = useState(!articleFromStore);


### PR DESCRIPTION
Addresses a runtime error `TypeError: Cannot read properties of undefined (reading 'find')` in `news-blink-frontend/src/pages/BlinkDetail.tsx`.

The error occurred because `state.news` within the `useNewsStore` hook was potentially undefined when the component attempted to call `.find()` on it.

The fix ensures that `state.news` defaults to an empty array (`[]`) before `.find()` is called, by changing the accessor from `state.news.find(...)` to `(state.news || []).find(...)`. This prevents the TypeError and allows the component to render correctly even if the news data is not yet available in the store.