### PR TITLE
Fix: Prevent click event propagation on vote buttons

### DIFF
--- a/news-blink-frontend/src/components/PowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/PowerBarVoteSystem.tsx
@@ -93,7 +93,7 @@ export const PowerBarVoteSystem = ({
       {/* Vote Buttons */}
       <div className="flex items-center justify-between gap-6">
         <button
-          onClick={() => handleVote('like')}
+          onClick={(e) => { e.stopPropagation(); handleVote('like'); }}
           disabled={isVoting}
           className={`flex items-center justify-center space-x-4 px-6 py-3 rounded-xl font-semibold transition-all duration-300 flex-1 transform hover:scale-[1.02] active:scale-[0.98] ${
             userVoteStatusFromStore === 'positive'
@@ -110,7 +110,7 @@ export const PowerBarVoteSystem = ({
         </button>
 
         <button
-          onClick={() => handleVote('dislike')}
+          onClick={(e) => { e.stopPropagation(); handleVote('dislike'); }}
           disabled={isVoting}
           className={`flex items-center justify-center space-x-4 px-6 py-3 rounded-xl font-semibold transition-all duration-300 flex-1 transform hover:scale-[1.02] active:scale-[0.98] ${
             userVoteStatusFromStore === 'negative'


### PR DESCRIPTION
Addresses an issue where clicking the vote buttons in `PowerBarVoteSystem` would inadvertently trigger navigation to the article detail page. This was caused by the click event bubbling up to a parent component that handled navigation.

The fix involves adding `e.stopPropagation()` to the `onClick` handlers of both the "like" and "dislike" buttons within the `PowerBarVoteSystem.tsx` component. This ensures that the click event is confined to the button itself and does not affect parent elements.