### PR TITLE
Fix: Prevent full list reload and improve vote count synchronization

### DIFF
--- a/news-blink-frontend/src/components/PowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/PowerBarVoteSystem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'; // Added React import
+import React, { useState, useEffect } from 'react'; // Added React import
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useNewsStore } from '@/store/newsStore';
@@ -21,6 +21,11 @@ export const PowerBarVoteSystem = ({
 
   const handleVoteFromStore = useNewsStore((state) => state.handleVote);
   const userVoteStatusFromStore = useNewsStore((state) => state.userVotes[articleId] || null);
+
+  useEffect(() => {
+    setLikes(initialLikes);
+    setDislikes(initialDislikes);
+  }, [initialLikes, initialDislikes]);
 
   const total = likes + dislikes;
   const likePercentage = total > 0 ? (likes / total) * 100 : 50;

--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -13,7 +13,11 @@ import { useTheme } from '@/contexts/ThemeContext';
 const Index = () => {
   const { isDarkMode } = useTheme();
   // Obteniendo TODO el estado desde el store de Zustand
-  const { blinks, isLoading, error, fetchBlinks, heroBlink } = useNewsStore();
+  const blinks = useNewsStore(state => state.blinks);
+  const isLoading = useNewsStore(state => state.isLoading);
+  const error = useNewsStore(state => state.error);
+  const fetchBlinks = useNewsStore(state => state.fetchBlinks);
+  const heroBlink = useNewsStore(state => state.heroBlink);
 
   // El hook de filtro ahora recibe los blinks del store
   const {


### PR DESCRIPTION
This commit includes two main improvements:

1.  **Prevent Full List Reload in `Index.tsx`**: I refactored `Index.tsx` to use selective subscriptions (individual selectors) for the `useNewsStore` (Zustand) hook. This prevents the main page from re-rendering unnecessarily when unrelated parts of the store state change (e.g., `userVotes` map), which was causing a perceived "reload all blinks" issue. Components should now only re-render if the specific data they subscribe to changes.

2.  **Improve Vote Count Sync in `PowerBarVoteSystem.tsx`**: I added a `useEffect` hook to `PowerBarVoteSystem.tsx`. This hook ensures that the component's local state for `likes` and `dislikes` (used for display) is updated if the `initialLikes` or `initialDislikes` props change. This makes the component more reactive to changes in the underlying news item data passed from its parent.

Note: For persistent vote counting and subsequent features like reordering blinks by interest, the `useNewsStore`'s `handleVote` action must ensure it updates the like/dislike counts directly on the blink items within the store's `blinks` array.