### PR TITLE
Fix: Enforce consistent height for FuturisticNewsCard

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -54,7 +54,7 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
       onClick={handleCardClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="cursor-pointer h-auto min-h-[600px] flex flex-col"
+      className="cursor-pointer flex flex-col h-[600px] overflow-hidden"
     >
       <div className={`relative h-full flex flex-col ${isDarkMode
         ? 'bg-gray-900'


### PR DESCRIPTION
Addresses an issue where news cards (blinks) were displaying with variable heights. This change ensures all cards maintain a uniform height.

Modified `FuturisticNewsCard.tsx`:
- Changed the outermost div's classes from `h-auto min-h-[600px]` to `h-[600px]`.
- Added `overflow-hidden` to the same div to prevent content from spilling if it exceeds the fixed height.

This should result in a more visually consistent grid of news cards.