### PR TITLE
Fix: Improve card height consistency using grid-based equalization

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -54,7 +54,7 @@ export const FuturisticNewsCard = memo(({ news, onCardClick }: FuturisticNewsCar
       onClick={handleCardClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      className="cursor-pointer flex flex-col h-[600px] overflow-hidden"
+      className="cursor-pointer h-full min-h-[600px] flex flex-col"
     >
       <div className={`relative h-full flex flex-col ${isDarkMode
         ? 'bg-gray-900'


### PR DESCRIPTION
This commit addresses the issue of news cards (blinks) displaying with variable heights. The previous fix involving a strict `h-[600px]` and `overflow-hidden` was reverted as it could lead to content being cut off.

This revised solution aims for better height equalization by leveraging CSS Grid and Flexbox properties:

- Modified `FuturisticNewsCard.tsx`:
  - Changed the outermost `div`'s `h-auto` class to `h-full`. It now uses `h-full min-h-[600px] flex flex-col`. This allows the card to take the full height allocated by its parent grid cell in `NewsGrid.tsx`.

This approach should result in cards within the same row stretching to the height of the tallest card in that row, providing visual consistency without arbitrarily truncating content from the entire card. Internal content areas within the card will use flex properties to distribute space.