### PR TITLE
Opt: Stabilize onCardClick callback for FuturisticNewsCard

### DIFF
--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 // news-blink-frontend/src/pages/Index.tsx
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useNewsStore, NewsItem as Blink } from '@/store/newsStore'; // Import NewsItem as Blink
 import { Header } from '@/components/Header';
 import { Newsletter } from '@/components/Newsletter';
@@ -43,10 +43,10 @@ const Index = () => {
     fetchBlinks();
   };
 
-  const handleCardClick = (id: string) => {
+  const handleCardClick = useCallback((id: string) => {
     // Idealmente, usar React Router para la navegación sin recargar la página
     window.location.href = `/blink/${id}`;
-  };
+  }, []); // Empty dependency array as it doesn't depend on any values from the component scope
 
   const categories = [
     { value: 'all', label: 'Todas' },


### PR DESCRIPTION
This commit wraps the `handleCardClick` function in `Index.tsx` with `useCallback`. This provides a stable function reference for the `onCardClick` prop that is passed down to `FuturisticNewsCard` components.

Previously, a new `handleCardClick` function was created on every render of `Index.tsx`, causing the `onCardClick` prop to change for all cards. This, in turn, made the `React.memo` custom comparison function on `FuturisticNewsCard` determine that props had changed, leading to unnecessary re-renders of all cards even if their individual data was unchanged.

By stabilizing `onCardClick`, `React.memo` can now more effectively prevent these unnecessary re-renders. This is expected to significantly improve the performance and smoothness of list reordering animations handled by `react-flip-toolkit` in `NewsGrid.tsx`, and reduce the perception of the entire list "reloading" during a sort.