### PR TITLE
Debug: Add specific log for onCardClick reference check in card memo

### DIFF
--- a/news-blink-frontend/src/components/FuturisticNewsCard.tsx
+++ b/news-blink-frontend/src/components/FuturisticNewsCard.tsx
@@ -15,6 +15,8 @@ const futuristicNewsCardPropsAreEqual = (prevProps: FuturisticNewsCardProps, nex
   const prevNews = prevProps.news;
   const nextNews = nextProps.news;
 
+  console.log(`[propsAreEqual ${nextProps.news.id}] Comparing onCardClick references: prev === next is`, prevProps.onCardClick === nextProps.onCardClick);
+
   // Primary check: If ID is different, it's a different item.
   if (prevNews.id !== nextNews.id) {
     console.log(`[propsAreEqual ${nextProps.news.id}] ID changed: ${prevNews.id} vs ${nextProps.news.id}`);


### PR DESCRIPTION
To definitively track the reference stability of the `onCardClick` prop passed to `FuturisticNewsCard`, this commit adds a specific `console.log` statement within the `futuristicNewsCardPropsAreEqual` custom comparison function.

This new log directly outputs the boolean result of `prevProps.onCardClick === nextProps.onCardClick`.

This will help confirm whether the `onCardClick` prop's reference is truly changing during list updates, or if previous logs might have been misinterpreted. This is crucial for diagnosing the cause of unnecessary re-renders of news cards during sorting or data refresh operations.