### PR TITLE
Fix: Prevent NewsGrid unmount during data refresh after vote

### DIFF
--- a/news-blink-frontend/src/components/NewsContent.tsx
+++ b/news-blink-frontend/src/components/NewsContent.tsx
@@ -44,7 +44,7 @@ export const NewsContent = ({
   }
   const { isDarkMode } = useTheme();
 
-  if (loading) {
+  if (loading && filteredNews.length === 0) {
     return <LoadingState />;
   }
 


### PR DESCRIPTION
Addresses the "disappear and reappear" issue when blinks reorder after a vote. This was caused by `NewsContent.tsx` rendering a `LoadingState` component (thus unmounting `NewsGrid`) while new data was being fetched via `fetchBlinks()`, even if items were already displayed.

The fix modifies `NewsContent.tsx` to only show the `LoadingState` if `loading` is true AND `filteredNews` is currently empty. If news items are already displayed, they will remain visible during the background data refresh. `NewsGrid` will then receive the updated data, and `react-flip-toolkit` will animate the changes in place.

This should prevent the jarring visual effect of the entire news grid disappearing and reappearing, leading to a smoother UX during vote-triggered reordering.