### PR TITLE
Fix: Correct Hero selection and time elapsed display

### DIFF
--- a/news-blink-frontend/src/pages/Index.tsx
+++ b/news-blink-frontend/src/pages/Index.tsx
@@ -17,7 +17,7 @@ const Index = () => {
   const isLoading = useNewsStore(state => state.isLoading);
   const error = useNewsStore(state => state.error);
   const fetchBlinks = useNewsStore(state => state.fetchBlinks);
-  const heroBlink = useNewsStore(state => state.heroBlink);
+  // const heroBlink = useNewsStore(state => state.heroBlink);
 
   // El hook de filtro ahora recibe los blinks del store
   const {
@@ -32,7 +32,7 @@ const Index = () => {
   } = useNewsFilter(blinks, 'tendencias');
 
   // El heroBlink ahora viene directamente del store, que ya tiene la lógica del blink destacado
-  const heroNews = heroBlink;
+  const heroNews = filteredNews.length > 0 ? filteredNews[0] : null;
 
   // Cargar las noticias cuando el componente se monta por primera vez
   useEffect(() => {

--- a/news-blink-frontend/src/utils/api.ts
+++ b/news-blink-frontend/src/utils/api.ts
@@ -1,4 +1,26 @@
 // Helper function to get or generate a simple userId
+
+function formatTimeAgo(isoDateString: string): string {
+  const date = new Date(isoDateString);
+  const now = new Date();
+  const seconds = Math.round((now.getTime() - date.getTime()) / 1000);
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(minutes / 60);
+  const days = Math.round(hours / 24);
+  const weeks = Math.round(days / 7);
+  const months = Math.round(days / 30.44); // Average days in month
+  const years = Math.round(days / 365.25);
+
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  if (weeks < 5) return `${weeks}w ago`; // Up to 4 weeks
+  if (months < 12) return `${months}mo ago`;
+  return `${years}y ago`;
+}
+
 const getUserId = (): string => {
   let userId = localStorage.getItem('blinkUserId');
   if (!userId) {
@@ -69,7 +91,7 @@ export const transformBlinkToNewsItem = (blink: any): NewsItem => {
     points: Array.isArray(blink.points) ? blink.points : [],
     category: (Array.isArray(blink.categories) && blink.categories.length > 0 ? blink.categories[0] : blink.category) || 'general',
     isHot: typeof blink.isHot === 'boolean' ? blink.isHot : false, // Or derive from interestPercentage later
-    readTime: blink.readTime || 'N/A',
+    readTime: formatTimeAgo(publishedAtDate),
     publishedAt: publishedAtDate,
     aiScore: typeof blink.aiScore === 'number' ? blink.aiScore : undefined,
     votes: finalVotes,


### PR DESCRIPTION
This commit addresses two issues you identified:

1.  **Hero News Selection on "Ultimas" Tab**:
    - I modified `Index.tsx` to derive the `heroNews` from the `filteredNews[0]` (the first item of the currently sorted and filtered list).
    - This ensures that when the "Ultimas" (Latest) tab is active, the hero/featured item displayed is the actual newest article, and when "Tendencias" (Trends) is active, it's the top-voted one.

2.  **Time Elapsed Display Showing "N/A"**:
    - I added a `formatTimeAgo` utility function in `utils/api.ts`.
    - I modified the `transformBlinkToNewsItem` function in `utils/api.ts` to use this utility to calculate a human-readable relative time (e.g., "5m ago", "2h ago") from the article's `publishedAtDate` (derived from `timestamp` or `publishedAt` fields).
    - This calculated string is now assigned to the `readTime` property of `NewsItem` objects, resolving the issue where "N/A" was displayed on cards.