### PR TITLE
Fix: Correct interest bar display logic

### DIFF
--- a/news-blink-frontend/src/store/newsStore.ts
+++ b/news-blink-frontend/src/store/newsStore.ts
@@ -34,27 +34,16 @@ export const useNewsStore = create<NewsState>((set, get) => ({
     try {
       const newsItems = await apiFetchBlinks(); // apiFetchBlinks returns NewsItem[]
 
-      const interesMaximo = newsItems.length > 0
-                              ? newsItems.reduce((max, p) => p.interest > max ? p.interest : max, newsItems[0].interest)
-                              : 0;
-
-      const absInteresMaximo = Math.abs(interesMaximo);
-
       const processedNewsItems = newsItems.map(item => {
-        let displayInterest = 0;
-        if (absInteresMaximo !== 0) { // Prevent division by zero
-          displayInterest = (item.interest / absInteresMaximo) * 100;
-        } else if (item.interest === 0 && interesMaximo === 0) {
-           displayInterest = 0;
-        } else if (item.interest > 0 && interesMaximo === 0){
-           displayInterest = 100;
-        }
-        // Ensure displayInterest is a finite number, default to 0 if not (e.g. NaN from 0/0 if not handled above)
-        displayInterest = Number.isFinite(displayInterest) ? displayInterest : 0;
+        let newDisplayInterest = 0;
+        // Use (item.interest || 0) to default to 0 if item.interest is null, undefined, or NaN,
+        // although item.interest should ideally always be a number from the backend.
+        const currentInterest = typeof item.interest === 'number' && Number.isFinite(item.interest) ? item.interest : 0;
+        newDisplayInterest = Math.max(0, Math.min(100, currentInterest));
 
         return {
           ...item,
-          displayInterest: displayInterest
+          displayInterest: newDisplayInterest
         };
       });
 


### PR DESCRIPTION
The calculation for `displayInterest` in `newsStore.ts` has been modified to eliminate normalization against other articles. The displayed interest is now a direct representation of the backend's `item.interest` value, clamped between 0 and 100%.

This change addresses two issues:
1. A bug where blinks with 1 like and 0 dislikes incorrectly showed 0% interest. They will now show the actual calculated interest percentage (approx. 17%).
2. The interest bar display was perceived as irregular because it was relative to the maximum interest of all loaded articles. The display is now independent for each article, providing a more stable and intuitive representation of interest.

The variables `interesMaximo` and `absInteresMaximo` were removed from `newsStore.ts` as they are no longer needed.