### PR TITLE
Fix: Ensure interest data integrity and correct display

### DIFF
--- a/news-blink-frontend/src/utils/api.ts
+++ b/news-blink-frontend/src/utils/api.ts
@@ -57,15 +57,11 @@ export const transformBlinkToNewsItem = (blink: any): NewsItem => {
   console.log('[transformBlinkToNewsItem] Received blink keys:', Object.keys(blink));
   console.log(`[utils/api.ts transformBlinkToNewsItem] Input blink (ID: ${blink?.id}): interest = ${blink?.interest}`);
 
-  let finalVotes = { likes: 0, dislikes: 0 }; // Use likes/dislikes
-  if (blink.votes && typeof blink.votes === 'object') {
-    const parsedLikes = parseInt(String(blink.votes.likes), 10); // Use blink.votes.likes
-    const parsedDislikes = parseInt(String(blink.votes.dislikes), 10); // Use blink.votes.dislikes
-    finalVotes = {
-      likes: !isNaN(parsedLikes) ? parsedLikes : 0,
-      dislikes: !isNaN(parsedDislikes) ? parsedDislikes : 0,
-    };
-  }
+  // Correctly map positive_votes and negative_votes from backend
+  const finalVotes = {
+    likes: typeof blink.positive_votes === 'number' ? blink.positive_votes : 0,
+    dislikes: typeof blink.negative_votes === 'number' ? blink.negative_votes : 0
+  };
 
   let publishedAtDate = new Date().toISOString(); // Default to now
   if (blink.publishedAt) {


### PR DESCRIPTION
This commit addresses issues with the interest bar display by:

1. Backend (`news-blink-backend/src/routes/api.py`):
    - Aggressively ensuring the 'interest' field for every blink item is a valid Python float immediately before the `/api/blinks` endpoint returns its JSON response.
    - Added logging to sample blink data on the backend just before serialization to help verify the state of the 'interest' field.
    - This aims to fix the problem where the 'interest' field was missing or undefined for many items when received by the frontend.

2. Frontend (`news-blink-frontend/src/utils/api.ts`):
    - Corrected the `transformBlinkToNewsItem` function to properly map `positive_votes` and `negative_votes` from the backend payload to the `NewsItem.votes.likes` and `NewsItem.votes.dislikes` fields.

3. Frontend (`news-blink-frontend/src/store/newsStore.ts`):
    - Retained the previously implemented logic to calculate `displayInterest` by clamping the received `item.interest` (now expected to be a valid number) between 0 and 100. This removes the previous normalization against other articles, making the display more intuitive.

These changes combined should ensure that vote counts are correctly processed, the interest is reliably calculated and transmitted by the backend, and the frontend displays this interest accurately and consistently.