### PR TITLE
Fix: Correct SyntaxError in get_blink method of models.py

### DIFF
--- a/models/news.py
+++ b/models/news.py
@@ -135,17 +135,19 @@ class News:
                 # Add currentUserVoteStatus
                 if user_id:
                     data['currentUserVoteStatus'] = self._get_user_vote_status(data, user_id)
-            # Specific log for VoteFixLog when getting blink for a user (likely for voting/display)
-            vote_fix_logger_model_level.info(f"get_blink for voting/display: id='{blink_id}', user_id='{user_id}'. Votes: {data.get('votes')}, UserVotes: {data.get('user_votes', {}).get(user_id, 'N/A')}, Determined status: {data['currentUserVoteStatus']}")
+                    # Specific log for VoteFixLog when getting blink for a user (likely for voting/display)
+                    vote_fix_logger_model_level.info(f"get_blink for voting/display: id='{blink_id}', user_id='{user_id}'. Votes: {data.get('votes')}, UserVotes: {data.get('user_votes', {}).get(user_id, 'N/A')}, Determined status: {data['currentUserVoteStatus']}")
                 else:
                     data['currentUserVoteStatus'] = None
-            vote_fix_logger_model_level.debug(f"get_blink for general purpose: id='{blink_id}', no user_id. Votes: {data.get('votes')}")
-
+                    # Log for general purpose when no user_id is present
+                    vote_fix_logger_model_level.debug(f"get_blink for general purpose: id='{blink_id}', no user_id. Votes: {data.get('votes')}")
 
                 app_logger.debug(f"Successfully loaded blink_id='{blink_id}'. Votes: {data.get('votes')}, UserVote: {data.get('currentUserVoteStatus')}")
                 return data
             except Exception as e:
-                app_logger.error(f"Error reading blink_id='{blink_id}' from {filepath}: {e}", exc_info=True)
+                app_logger.error(f"Error reading or processing blink_id='{blink_id}' from {filepath}: {e}", exc_info=True)
+                # Optionally, add a VoteFixLogLogger error here too if this specific log file needs to capture this error
+                vote_fix_logger_model_level.error(f"Error reading or processing blink_id='{blink_id}' in get_blink: {e}", exc_info=True)
         else:
             app_logger.warning(f"Blink file not found for blink_id='{blink_id}' at {filepath}")
         return None


### PR DESCRIPTION
This commit fixes a SyntaxError in the `get_blink` method within `models/news.py`. The error was caused by misplaced code, including an `else` clause and logging statements, between the `try` block and its corresponding `except` block.

The code has been restructured to ensure that all operations dependent on the successful loading of file data are correctly positioned within the `try` block. This resolves the `SyntaxError: expected 'except' or 'finally' block` and ensures correct logical flow.

Additional logging to `VoteFixLogLogger` has also been added to the `except` block in `get_blink` for more comprehensive error tracking related to vote data fetching.