### PR TITLE
Fix: Critical errors in frontend rendering and backend data

### DIFF
--- a/news-blink-backend/src/routes/api.py
+++ b/news-blink-backend/src/routes/api.py
@@ -157,6 +157,26 @@ def get_blinks():
             vote_fix_logger.info("--- DIAGNOSTIC LOG (Detail): sorted_blinks list is empty PRE-JSONIFY ---")
         # END DIAGNOSTIC LOGGING BLOCK
 
+        # --- ADDING NEW FINAL DATA SAMPLE LOGGING BLOCK ---
+        if sorted_blinks:
+            sample_size = min(3, len(sorted_blinks)) # Log up to 3 samples
+            vote_fix_logger.info(f"--- FINAL DATA SAMPLE PRE-JSONIFY for /blinks (first {sample_size} of {len(sorted_blinks)}) ---")
+            for i in range(sample_size):
+                blink_to_log = sorted_blinks[i]
+                log_output = {
+                    "id": blink_to_log.get("id", "N/A"),
+                    "title_snippet": blink_to_log.get("title", "N/A")[:30], # Snippet of title
+                    "positive_votes": blink_to_log.get("positive_votes", "MISSING_OR_UNDEFINED"),
+                    "negative_votes": blink_to_log.get("negative_votes", "MISSING_OR_UNDEFINED"),
+                    "interest": blink_to_log.get("interest", "MISSING_OR_UNDEFINED"),
+                    "publication_date": blink_to_log.get("publication_date", "N/A")
+                }
+                vote_fix_logger.info(f"Item {i+1}: {log_output}")
+            vote_fix_logger.info(f"--- END FINAL DATA SAMPLE ---")
+        else:
+            vote_fix_logger.info("--- FINAL DATA PRE-JSONIFY for /blinks: sorted_blinks list is empty ---")
+        # --- END OF NEW FINAL DATA SAMPLE LOGGING BLOCK ---
+
         vote_fix_logger.info(f"Returning {len(sorted_blinks)} blinks.")
         return jsonify(sorted_blinks)
     except Exception as e:

--- a/news-blink-frontend/src/components/PowerBarVoteSystem.tsx
+++ b/news-blink-frontend/src/components/PowerBarVoteSystem.tsx
@@ -48,9 +48,11 @@ export const PowerBarVoteSystem = ({
 
   const handleVote = async (voteType: 'like' | 'dislike') => {
     const previousVoteStatus = userVoteStatusFromStore; // Capture before any changes
-    console.log(`${handleVoteLogPrefix} Called with voteType: ${voteType}. Current isVoting: ${isVotingInternal}, userVoteStatusFromStore: ${previousVoteStatus}`);
+    // Corrected: Log the actual state variable 'isVoting' instead of the setter 'isVotingInternal'
+    console.log(`${handleVoteLogPrefix} Called with voteType: ${voteType}. Current isVoting: ${isVoting}, userVoteStatusFromStore: ${previousVoteStatus}`);
 
-    if (isVotingInternal) {
+    // Corrected: Use the actual state variable 'isVoting' for the check
+    if (isVoting) {
       console.log(`${handleVoteLogPrefix} Already voting, exiting.`);
       return;
     }
@@ -147,7 +149,7 @@ export const PowerBarVoteSystem = ({
     percentageToShow: percentageToShow.toFixed(2),
     barWidthPercentage: barWidthPercentage.toFixed(2),
     userVoteStatusFromStore,
-    isVoting: isVotingInternal
+    isVoting: isVoting // Corrected: Log the actual state variable 'isVoting'
   });
 
   return (
@@ -188,7 +190,7 @@ export const PowerBarVoteSystem = ({
       <div className="flex items-center justify-between gap-6">
         <button
           onClick={(e) => { e.stopPropagation(); handleVote('like'); }}
-          disabled={isVoting}
+          disabled={isVoting} // This was already correct, using the state variable 'isVoting'
           className={`flex items-center justify-center space-x-4 px-6 py-3 rounded-xl font-semibold transition-all duration-300 flex-1 transform hover:scale-[1.02] active:scale-[0.98] ${
             userVoteStatusFromStore === 'positive'
               ? isDarkMode
@@ -205,7 +207,7 @@ export const PowerBarVoteSystem = ({
 
         <button
           onClick={(e) => { e.stopPropagation(); handleVote('dislike'); }}
-          disabled={isVoting}
+          disabled={isVoting} // This was already correct, using the state variable 'isVoting'
           className={`flex items-center justify-center space-x-4 px-6 py-3 rounded-xl font-semibold transition-all duration-300 flex-1 transform hover:scale-[1.02] active:scale-[0.98] ${
             userVoteStatusFromStore === 'negative'
               ? isDarkMode


### PR DESCRIPTION
This commit addresses several critical issues:
1.  **Frontend ReferenceError:** I corrected a `ReferenceError: isVotingInternal is not defined` in `PowerBarVoteSystem.tsx`. The `isVoting` state variable was being incorrectly referred to as `isVotingInternal` in a logging statement and a conditional check within `handleVote`. This has been rectified to use the correct state variable `isVoting`.

2.  **Backend Data Verification:** I added specific diagnostic logging in `news-blink-backend/src/routes/api.py` within the `get_blinks` function. This new logging occurs immediately before the `jsonify` call to output a sample of the blinks being sent, explicitly showing `positive_votes`, `negative_votes`, and `interest`. This helps confirm the integrity of these fields in the data dispatched to the frontend. I reviewed the existing logic for populating these fields and deemed it correct.

3.  **Log Setup Re-Verification:** I re-verified the code responsible for clearing the `PROJECT_ROOT/LOG/` directory on backend startup (in `news-blink-backend/src/app.py`) and for initializing `VoteFixLog.log` (in `news-blink-backend/src/routes/api.py`). The paths and logic appear correct.

These fixes aim to resolve the immediate frontend crash and provide clearer diagnostics for backend data handling, as well as re-confirming the logging infrastructure setup.