### PR TITLE
feat: Activate 'HOT' labels for featured and top posts

### DIFF
--- a/news-blink-backend/src/routes/api.py
+++ b/news-blink-backend/src/routes/api.py
@@ -159,6 +159,17 @@ def get_blinks():
         sorted_blinks = sorted(all_blinks, key=cmp_to_key(compare_blinks))
         vote_fix_logger.info("Sorting complete.")
 
+        # Implement isHot logic
+        vote_fix_logger.info("Applying isHot logic.")
+        for i, blink in enumerate(sorted_blinks):
+            if i < 4:
+                blink['isHot'] = True
+                vote_fix_logger.info(f"Blink {blink.get('id', 'N/A')} marked as isHot=True (index {i})")
+            else:
+                blink['isHot'] = False
+                vote_fix_logger.info(f"Blink {blink.get('id', 'N/A')} marked as isHot=False (index {i})")
+        vote_fix_logger.info("isHot logic application complete.")
+
         # Log sample of sorted blinks and total count
         if sorted_blinks:
             vote_fix_logger.info(f"Total blinks being returned after sorting: {len(sorted_blinks)}")
@@ -177,6 +188,7 @@ def get_blinks():
                     "positive_votes": blink_to_log.get("positive_votes", "N/A"),
                     "negative_votes": blink_to_log.get("negative_votes", "N/A"),
                     "interest": blink_to_log.get("interest", "N/A"),
+                    "isHot": blink_to_log.get("isHot", "N/A"),  # Added for isHot logging
                     "publication_date": blink_to_log.get("publication_date", "N/A")
                 }
                 vote_fix_logger.info(f"Blink {i+1} sample (detail): {log_output}")
@@ -197,6 +209,7 @@ def get_blinks():
                     "positive_votes": blink_to_log.get("positive_votes", "MISSING_OR_UNDEFINED"),
                     "negative_votes": blink_to_log.get("negative_votes", "MISSING_OR_UNDEFINED"),
                     "interest": blink_to_log.get("interest", "MISSING_OR_UNDEFINED"),
+                    "isHot": blink_to_log.get("isHot", "MISSING_OR_UNDEFINED"), # Added for isHot logging
                     "publication_date": blink_to_log.get("publication_date", "N/A")
                 }
                 vote_fix_logger.info(f"Item {i+1}: {log_output}")


### PR DESCRIPTION
This commit activates the 'HOT' labels with the fire icon for the featured post and the three subsequent posts on your news feed.

Backend changes:
- Modified the `/api/blinks` endpoint in `news-blink-backend/src/routes/api.py`.
- After sorting the articles, the `isHot` property is now set to `true` for the first four articles in the list.
- All other articles will have `isHot` set to `false`.

Frontend changes:
- No direct frontend code changes were required for this feature, as the components (`FuturisticNewsCard.tsx`, `FuturisticHeroCard.tsx`) and data handling logic (`utils/api.ts`, `store/newsStore.ts`) already supported the `isHot` property.

Testing:
- Added a new test method `test_is_hot_property` to `tests/test_api_sorting.py`.
- This test verifies that the `/api/blinks` endpoint correctly sets the `isHot` property for:
    - Scenarios with more than 4 articles.
    - Scenarios with fewer than 4 articles.