### PR TITLE
Fix: Ensure VoteFixLog.log is generated by correcting logger initiali…

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import logging
 import logging.handlers
 from flask import Flask
 from flask_cors import CORS
+from news_blink_backend.src.logger_config import app_logger as configured_app_logger
 from routes.api import init_api
 from routes.topic_search import topic_search_bp
 
@@ -32,39 +33,24 @@ def create_app():
     app = Flask(__name__)
     CORS(app, origins="*")  # Habilitar CORS para permitir solicitudes desde el frontend
 
+    # Integrate configured_app_logger into Flask's app.logger
+    # Remove Flask's default handlers
+    for handler in list(app.logger.handlers):
+        app.logger.removeHandler(handler)
+    # Add handlers from our configured_app_logger
+    for handler in configured_app_logger.handlers:
+        app.logger.addHandler(handler)
+    # Set Flask's app.logger level to match our configured_app_logger's level
+    app.logger.setLevel(configured_app_logger.level)
+    # Prevent Flask's app.logger from propagating to the root logger,
+    # as we've explicitly set its handlers from configured_app_logger.
+    app.logger.propagate = False
+
+    app.logger.info("Root app.logger configured to use handlers from configured_app_logger (VoteFixLog.log).")
+
     # Cargar configuración de la aplicación
     app_config = load_app_config(app)
     app.config['APP_CONFIG'] = app_config
-
-    # --- Setup for dedicated blink sorting warnings logger ---
-    LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'LOG')
-    if not os.path.exists(LOG_DIR):
-        os.makedirs(LOG_DIR)
-
-    warnings_log_file = os.path.join(LOG_DIR, 'blink_sorting_warnings.log')
-
-    # Create a specific logger
-    warnings_logger = logging.getLogger('blink_sorting_warnings')
-    warnings_logger.setLevel(logging.INFO) # <-- CHANGED TO INFO
-
-    # Prevent propagation to root logger if you don't want duplicate console logs
-    # warnings_logger.propagate = False
-
-    # Create a file handler for this logger
-    file_handler = logging.FileHandler(warnings_log_file)
-    file_handler.setLevel(logging.INFO) # <-- CHANGED TO INFO
-
-    # Create a formatter and set it for the handler
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    file_handler.setFormatter(formatter)
-
-    # Add the handler to the logger
-    # Check if handlers are already added to prevent duplicates during reloads in debug mode
-    if not warnings_logger.handlers:
-        warnings_logger.addHandler(file_handler)
-
-    app.logger.info(f"Dedicated blink sorting warnings logger configured. Warnings will be saved to {warnings_log_file}")
-    # --- End of dedicated logger setup ---
     
     # Inicializar las rutas de la API
     init_api(app)
@@ -79,9 +65,8 @@ if __name__ == '__main__':
     app_instance = create_app()
     # The logger is configured by Flask. If running standalone, need to configure logging.
     # For example, if not in debug or if run directly via python app.py without Flask CLI:
-    if not app_instance.debug:
-        import logging
-        logging.basicConfig(level=logging.INFO)
+    # if not app_instance.debug: # Removed: logging.basicConfig
+    #     import logging
 
     app_instance.run(host='0.0.0.0', port=5000, debug=True, use_reloader=False)
 

--- a/news-blink-backend/src/logger_config.py
+++ b/news-blink-backend/src/logger_config.py
@@ -7,11 +7,15 @@ def setup_logger():
     # Robust path to project_root/LOG from news-blink-backend/src/logger_config.py
     log_dir_relative_to_file = os.path.join(os.path.dirname(__file__), '..', '..', 'LOG')
     log_directory = os.path.abspath(log_dir_relative_to_file)
+    print(f"[LoggerSetup] Resolved log directory: {log_directory}", flush=True)
 
+    print(f"[LoggerSetup] Checking if log directory exists: {log_directory}", flush=True)
     if not os.path.exists(log_directory):
         os.makedirs(log_directory)
+        print(f"[LoggerSetup] Created log directory. Exists now: {os.path.exists(log_directory)}", flush=True)
 
     log_file_path = os.path.join(log_directory, "VoteFixLog.log")
+    print(f"[LoggerSetup] Resolved log file path: {log_file_path}", flush=True)
 
     # Get the logger
     logger = logging.getLogger("blink_backend") # Use a specific name for our app's logger
@@ -21,26 +25,37 @@ def setup_logger():
     if logger.hasHandlers():
         logger.handlers.clear()
 
-    # File Handler
-    # Overwrites the log file on each run.
-    file_handler = logging.FileHandler(log_file_path, mode='w', encoding='utf-8')
-    file_handler.setLevel(logging.DEBUG) # Set level for file handler
-
-    # Console Handler (optional, good for development/debugging alongside file logs)
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.INFO) # Or DEBUG, depending on verbosity needed in console
-
-    # Log Formatter
+    # Log Formatter - Define formatter before try block for FileHandler
     formatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(module)s.%(funcName)s:%(lineno)d - %(message)s'
     )
-    file_handler.setFormatter(formatter)
-    console_handler.setFormatter(formatter)
 
-    # Add handlers to the logger
-    logger.addHandler(file_handler)
+    # File Handler
+    try:
+        print(f"[LoggerSetup] Attempting to create FileHandler for: {log_file_path}", flush=True)
+        # Overwrites the log file on each run.
+        file_handler = logging.FileHandler(log_file_path, mode='w', encoding='utf-8')
+        file_handler.setLevel(logging.DEBUG) # Set level for file handler
+
+        file_handler.setFormatter(formatter)
+
+        logger.addHandler(file_handler)
+        print(f"[LoggerSetup] SUCCESSFULLY added FileHandler for {log_file_path}. Logger '{logger.name}' handlers: {[type(h).__name__ for h in logger.handlers]}", flush=True)
+    except Exception as e:
+        print(f"[LoggerSetup] !!! ERROR setting up FileHandler for {log_file_path}: {e} !!!", flush=True)
+        # Optionally, re-raise or handle as critical failure
+
+    # Console Handler (optional, good for development/debugging alongside file logs)
+    # This setup is outside the try-except for the FileHandler.
+    # If it also needs protection, it would require its own try-except.
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO) # Or DEBUG, depending on verbosity needed in console
+    console_handler.setFormatter(formatter) # Assuming same formatter is okay
+
     # logger.addHandler(console_handler) # Uncomment if console output is also desired
+    # If console_handler is added, the print statement above would need adjustment or another one added.
 
+    print(f"[LoggerSetup] setup_logger function complete. Returning logger '{logger.name}'.", flush=True)
     return logger
 
 # Create a logger instance to be imported by other modules


### PR DESCRIPTION
…zation

- I modified the root app.py to correctly initialize Flask's app.logger using the configuration from news-blink-backend/src/logger_config.py. This ensures that the FileHandler for VoteFixLog.log is actually used by the running application.
- I removed the separate 'blink_sorting_warnings' logger and conflicting basicConfig from the root app.py.
- I added detailed diagnostic prints and a try-except block in news-blink-backend/src/logger_config.py to trace logger setup and catch FileHandler instantiation errors.
- The application should now correctly create and write to LOG/VoteFixLog.log.