### PR TITLE
Fix: Resolve ModuleNotFoundError for news_blink_backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 import json
 import os


### PR DESCRIPTION
I modified the root app.py to prepend its own directory to sys.path. This ensures that the 'news_blink_backend' package, located in the same directory as the main app.py, is discoverable by the Python interpreter, especially in containerized environments where the PYTHONPATH might not be automatically configured to include the application root.

This resolves the 'ModuleNotFoundError: No module named news_blink_backend' that occurred when attempting to import the logger configuration.