### PR TITLE
Fix: Unified application logging to VoteFixLog.log and resolved impor…

### DIFF
--- a/models/news.py
+++ b/models/news.py
@@ -1,4 +1,23 @@
 import os
+import sys
+print("DEBUG_MODELS_NEWS: --- Path Diagnostics (models/news.py) ---", flush=True)
+print(f"DEBUG_MODELS_NEWS: Current working directory (cwd): {os.getcwd()}", flush=True)
+print(f"DEBUG_MODELS_NEWS: sys.path: {sys.path}", flush=True)
+print(f"DEBUG_MODELS_NEWS: __file__: {__file__}", flush=True)
+print(f"DEBUG_MODELS_NEWS: os.path.abspath(os.path.dirname(__file__)): {os.path.abspath(os.path.dirname(__file__))}", flush=True)
+try:
+    print(f"DEBUG_MODELS_NEWS: Listing contents of cwd '{os.getcwd()}': {os.listdir(os.getcwd())}", flush=True)
+except Exception as e:
+    print(f"DEBUG_MODELS_NEWS: Error listing contents of cwd '{os.getcwd()}': {e}", flush=True)
+# Also list contents of /app if cwd is not /app, for comparison
+if os.getcwd() != '/app':
+    try:
+        print(f"DEBUG_MODELS_NEWS: Listing contents of '/app': {os.listdir('/app')}", flush=True)
+    except Exception as e:
+        print(f"DEBUG_MODELS_NEWS: Error listing contents of '/app': {e}", flush=True)
+print("DEBUG_MODELS_NEWS: --- End Path Diagnostics (models/news.py) ---", flush=True)
+
+# import os # os is already imported by the diagnostic block above
 import json
 from datetime import datetime, timezone
 from functools import cmp_to_key


### PR DESCRIPTION
…t errors

This commit culminates a series of changes to ensure all backend logging is consolidated into a single 'VoteFixLog.log' file and to resolve persistent 'ModuleNotFoundError' issues.

Key changes:
- Resolved 'ModuleNotFoundError: No module named news_blink_backend':
  - Added a step in the root app.py to rename the 'news_blink_backend.egg-info' directory to '.disabled' at runtime. This was found to be interfering with direct package imports. (Note: A long-term fix should involve reviewing the build/packaging process for news-blink-backend).
  - Added __init__.py files to 'news-blink-backend/' and 'news-blink-backend/src/' to ensure they are treated as Python packages.
  - Removed explicit sys.path manipulation from root app.py, relying on Python's default path resolution which includes the script's directory.

- Consolidated Logging to 'VoteFixLog.log':
  - news_blink_backend/src/logger_config.py now defines 'app_logger' which writes to 'LOG/VoteFixLog.log' in overwrite mode ('w').
  - The root app.py now correctly initializes Flask's app.logger to use the handlers from this central 'app_logger'.
  - models/news.py was confirmed to successfully import and use the central 'app_logger', so its fallback 'VOTINGPROBLEMLOG.log' is no longer created.
  - models/blink_generator.py was refactored to remove its independent timestamped 'blink_run_*.log' file setup and now also uses the central 'app_logger'.

- Diagnostics:
  - Retained extensive diagnostic print statements in root app.py, logger_config.py, and models/news.py that were instrumental in debugging the import and file I/O issues.

The application now starts correctly, imports necessary modules, and all relevant backend logging should be directed to '/app/LOG/VoteFixLog.log'.