### PR TITLE
Fix: Handle offset-naive and offset-aware datetime comparisons

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -63,11 +63,15 @@ def compare_blinks_custom(item1, item2):
 
     try:
         date1 = datetime.fromisoformat(date1_str.replace('Z', '+00:00'))
+        if date1.tzinfo is None or date1.tzinfo.utcoffset(date1) is None:
+            date1 = date1.replace(tzinfo=timezone.utc)
     except ValueError:
         logger.warning(f"Invalid date format for item1 ID {item1.get('id')}: {date1_str}. Using fallback date.")
         date1 = datetime.min.replace(tzinfo=timezone.utc) # Ensure timezone aware for comparison
     try:
         date2 = datetime.fromisoformat(date2_str.replace('Z', '+00:00'))
+        if date2.tzinfo is None or date2.tzinfo.utcoffset(date2) is None:
+            date2 = date2.replace(tzinfo=timezone.utc)
     except ValueError:
         logger.warning(f"Invalid date format for item2 ID {item2.get('id')}: {date2_str}. Using fallback date.")
         date2 = datetime.min.replace(tzinfo=timezone.utc) # Ensure timezone aware


### PR DESCRIPTION
Previously, the `compare_blinks_custom` function in `routes/api.py` could raise a TypeError when attempting to compare an offset-naive datetime object with an offset-aware one. This typically occurred if a blink's timestamp was stored or provided without timezone information.

This commit addresses the issue by:
1. Modifying `compare_blinks_custom` to ensure that all datetime objects are offset-aware (converted to UTC if naive) before comparison. This standardizes the timezone, allowing for correct sorting.

2. Adding a new test case, `test_sort_mixed_timezone_awareness`, to `tests/test_api_sorting.py`. This test specifically verifies that blinks with mixed timezone-aware and naive timestamps are sorted correctly.

3. Refactoring the `_create_blink_file` test helper in `tests/test_api_sorting.py` to accurately reflect the data structure (nested `votes` and `timestamp` field) used by the application. Existing tests within `TestApiBlinkSorting` were updated accordingly.

These changes ensure robust handling of datetime objects during blink sorting, preventing runtime errors and ensuring consistent ordering.