### PR TITLE
I've updated the logger configuration to append mode for debugging.

### DIFF
--- a/news_blink_backend/src/logger_config.py
+++ b/news_blink_backend/src/logger_config.py
@@ -34,7 +34,7 @@ def setup_logger():
     try:
         print(f"[LoggerSetup] Attempting to create FileHandler for: {log_file_path}", flush=True)
         # Overwrites the log file on each run.
-        file_handler = logging.FileHandler(log_file_path, mode='w', encoding='utf-8')
+        file_handler = logging.FileHandler(log_file_path, mode='a', encoding='utf-8')
         file_handler.setLevel(logging.DEBUG) # Set level for file handler
 
         file_handler.setFormatter(formatter)


### PR DESCRIPTION
Specifically, I changed the file handler mode in `news_blink_backend/src/logger_config.py` from 'w' (write/overwrite) to 'a' (append).

This change ensures that logs are preserved across application restarts. This is crucial for diagnosing issues like the missing 'HOT' labels, as it allows you to analyze logs from the specific session where the problem occurs.