### PR TITLE
Elimina archivos de blink de prueba estáticos

### DIFF
--- a/data/blinks/test_blink_main.json
+++ b/data/blinks/test_blink_main.json
@@ -1,9 +1,0 @@
-{
-    "id": "test_blink_main",
-    "title": "Blink test_blink_main",
-    "positive_votes": 0,
-    "negative_votes": 0,
-    "currentUserVoteStatus": null,
-    "publication_date": "2023-01-01T10:00:00Z",
-    "content": "Content for test_blink_main"
-}

--- a/data/blinks/test_blink_zero_votes.json
+++ b/data/blinks/test_blink_zero_votes.json
@@ -1,9 +1,0 @@
-{
-    "id": "test_blink_zero_votes",
-    "title": "Blink test_blink_zero_votes",
-    "positive_votes": 1,
-    "negative_votes": 0,
-    "currentUserVoteStatus": "like",
-    "publication_date": "2023-01-01T10:00:00Z",
-    "content": "Content for test_blink_zero_votes"
-}


### PR DESCRIPTION
Se eliminaron `data/blinks/test_blink_main.json` y `data/blinks/test_blink_zero_votes.json` ya que eran restos de pruebas anteriores y no son necesarios para el funcionamiento normal de la aplicación.